### PR TITLE
fix: standardize license to Apache-2.0 across all packages

### DIFF
--- a/mcpd-bridge-server/package.json
+++ b/mcpd-bridge-server/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": ["mcp", "mcpd", "bridge", "ai", "llm", "claude", "anthropic"],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla-ai/mcpd-client"

--- a/mcpd-http-gateway/package.json
+++ b/mcpd-http-gateway/package.json
@@ -17,7 +17,7 @@
   },
   "keywords": ["mcp", "mcpd", "http", "gateway", "api", "rest"],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.22.1",
     "cors": "^2.8.5",

--- a/mcpd-setup/package.json
+++ b/mcpd-setup/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.13.5",
     "fs-extra": "^11.0.0"
   },
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/fs-extra": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/mozilla-ai/mcpd-client/issues"


### PR DESCRIPTION
## Summary

- Root `package.json` license was ISC, bridge-server and http-gateway were MIT, mcpd-setup had no license field at all
- The repo `LICENSE` file has always been Apache 2.0 — this aligns all `package.json` declarations to match
- No code changes, only metadata

## Changes

| Package | Before | After |
|---|---|---|
| root (`mcpd-client`) | ISC | Apache-2.0 |
| `@mozilla-ai/mcpd-bridge-server` | MIT | Apache-2.0 |
| `@mozilla-ai/mcpd-http-gateway` | MIT | Apache-2.0 |
| `@mozilla-ai/mcpd-setup` | _(missing)_ | Apache-2.0 |

## Test plan

- [x] Verified all four packages build successfully
- [ ] Confirm license field appears correctly on npm when published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Licensing updated to Apache-2.0 across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->