### PR TITLE
chore: add ESLint, Prettier, and stricter TypeScript checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Install root dependencies
         run: npm ci
 
-      - name: Typecheck root
-        run: npx tsc --noEmit
+      - name: Lint and typecheck
+        run: npm run lint
 
       - name: Build root
         run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+release/
+node_modules/
+mcpd-setup/
+package-lock.json

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,6 +7,7 @@ mcpd exposes an HTTP API directly on port 8090. There is no need for a separate 
 ### Local Access
 
 The mcpd daemon provides a built-in HTTP API:
+
 ```bash
 # List servers
 curl http://localhost:8090/api/v1/servers
@@ -21,6 +22,7 @@ curl -X POST http://localhost:8090/api/v1/servers/filesystem/tools/read_file/cal
 ```
 
 Or use the JavaScript SDK:
+
 ```bash
 npm install @mozilla-ai/mcpd
 ```
@@ -30,18 +32,20 @@ import { McpdClient } from "@mozilla-ai/mcpd";
 
 const client = new McpdClient({ apiEndpoint: "http://localhost:8090" });
 const result = await client.servers.filesystem.callTool("read_file", {
-  path: "/tmp/test.txt"
+  path: "/tmp/test.txt",
 });
 ```
 
 ### IDE Integrations (STDIO)
 
 For Claude Desktop, Cursor, and other IDEs that require STDIO-based MCP servers, use mcpd-proxy:
+
 ```bash
 npx @mozilla-ai/mcpd-proxy
 ```
 
 Or use the setup CLI:
+
 ```bash
 mcpd-setup filesystem --client claude
 mcpd-setup filesystem --client cursor
@@ -54,16 +58,19 @@ When you need to connect external services to your local mcpd instance, you can 
 ### Option 1: Cloudflare Tunnel (Recommended - Free, No Account)
 
 **One command setup:**
+
 ```bash
 mcpd-setup filesystem --client tunnel
 ```
 
 This will:
+
 - Automatically install cloudflared if not present
 - Create a public tunnel to mcpd on port 8090
 - Display the public URL
 
 Or manually:
+
 ```bash
 cloudflared tunnel --url http://localhost:8090
 ```
@@ -87,23 +94,26 @@ npx localtunnel --port 8090
 ## Example: Connecting External App to Local mcpd
 
 ```javascript
-const MCPD_URL = process.env.MCPD_URL || 'https://your-tunnel.trycloudflare.com';
+const MCPD_URL =
+  process.env.MCPD_URL || "https://your-tunnel.trycloudflare.com";
 
 async function callMCPTool(server, toolName, args) {
   const response = await fetch(
     `${MCPD_URL}/api/v1/servers/${server}/tools/${toolName}/call`,
     {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ arguments: args })
-    }
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ arguments: args }),
+    },
   );
 
   return response.json();
 }
 
 // Example usage.
-const result = await callMCPTool('filesystem', 'read_file', { path: '/tmp/data.txt' });
+const result = await callMCPTool("filesystem", "read_file", {
+  path: "/tmp/data.txt",
+});
 ```
 
 ## Security Considerations

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A desktop app and CLI for managing MCP (Model Context Protocol) servers with Moz
 **Mozilla has NEVER published any packages from this project to npm.**
 
 The following malicious packages have been confirmed on the public npm registry:
+
 - `mcpd-bridge-server` - CONFIRMED MALICIOUS
 - `mcpd-http-gateway` - CONFIRMED EXISTS (treat as malicious)
 - `@mcpd/setup` - CONFIRMED EXISTS (treat as malicious)
@@ -18,9 +19,11 @@ If any other packages claiming to be from this project exist on npm, they should
 ## Core Components
 
 ### 1. **mcpd Client** (Electron App)
+
 Visual desktop application for managing MCP servers with dashboard, configuration editor, and real-time monitoring.
 
 ### 2. **mcpd Setup CLI**
+
 Command-line tool for quick setup of MCP servers with various clients (Claude, Cursor, Windsurf, HTTP).
 
 ## Features
@@ -132,6 +135,7 @@ The application consists of:
 The Connect tab provides the easiest way to integrate your MCP servers with various tools.
 
 For each configured server, click a button:
+
 - **Connect to Claude Desktop** - Configures `claude_desktop_config.json` with mcpd-proxy
 - **Connect to Cursor** - Configures `~/.cursor/mcp.json` with mcpd-proxy
 - **HTTP API Info** - Shows the mcpd HTTP API endpoint
@@ -139,6 +143,7 @@ For each configured server, click a button:
 ### CLI Tool
 
 After running `./install-global.sh`, you can use these commands from anywhere:
+
 ```bash
 # List available servers
 mcpd-setup list
@@ -198,7 +203,7 @@ const tools = await client.servers.filesystem.getTools();
 
 // Call a tool.
 const result = await client.servers.filesystem.callTool("read_file", {
-  path: "/tmp/test.txt"
+  path: "/tmp/test.txt",
 });
 ```
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,44 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  {
+    ignores: [
+      "dist/**",
+      "release/**",
+      "node_modules/**",
+      "mcpd-setup/**",
+    ],
+  },
+  {
+    files: ["**/*.{js,mjs,cjs,ts,tsx}"],
+    plugins: { js },
+    extends: ["js/recommended"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+  },
+  tseslint.configs.recommended,
+  // CommonJS files legitimately use require().
+  {
+    files: ["**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  // Project-wide overrides.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      // Too many any usages to fix at once; warn for now, tighten later.
+      "@typescript-eslint/no-explicit-any": "warn",
+      // Allow require() in Electron main process for dynamic imports.
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
@@ -28,10 +29,15 @@
         "css-loader": "^7.1.2",
         "electron": "^37.3.0",
         "electron-builder": "^26.7.0",
+        "eslint": "^10.0.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.3.0",
         "html-webpack-plugin": "^5.6.4",
+        "prettier": "^3.8.1",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.9.2",
+        "typescript-eslint": "^8.56.0",
         "webpack": "^5.105.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
@@ -620,6 +626,186 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "license": "MIT"
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.1.tgz",
+      "integrity": "sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.1",
+        "debug": "^4.3.1",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.1.tgz",
+      "integrity": "sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
@@ -1284,6 +1470,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1543,6 +1736,270 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -1843,6 +2300,16 @@
       },
       "peerDependencies": {
         "acorn": "^8.14.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -2265,19 +2732,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/app-builder-lib/node_modules/which": {
@@ -3611,9 +4065,9 @@
       "peer": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3656,6 +4110,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.2.1",
@@ -4491,12 +4952,84 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.0.tgz",
+      "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.0",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.0",
+        "eslint-visitor-keys": "^5.0.0",
+        "espree": "^11.1.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.1.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4511,6 +5044,138 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.0.tgz",
+      "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
+      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
@@ -4544,6 +5209,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -4690,6 +5365,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -4756,6 +5438,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/filelist": {
@@ -4870,6 +5565,27 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -5174,6 +5890,19 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -5662,6 +6391,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -6078,6 +6817,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -6155,6 +6901,20 @@
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.1",
@@ -6663,6 +7423,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -6939,6 +7706,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -7389,6 +8174,32 @@
       "optional": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-error": {
@@ -8663,9 +9474,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9563,14 +10374,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9655,6 +10466,19 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-loader": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
@@ -9693,6 +10517,19 @@
       "dev": true,
       "license": "0BSD",
       "peer": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -9735,6 +10572,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undici-types": {
@@ -10196,6 +11057,16 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,13 @@
     "dist": "npm run build && electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",
-    "dist:linux": "npm run build && electron-builder --linux"
+    "dist:linux": "npm run build && electron-builder --linux",
+    "lint": "npm run format:check && eslint . && npm run typecheck",
+    "lint:fix": "npm run format && eslint . --fix && npm run typecheck",
+    "format": "prettier --write \"**/*.{ts,tsx,json,md,css}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,json,md,css}\"",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run lint:fix && npm run build"
   },
   "repository": {
     "type": "git",
@@ -61,6 +67,7 @@
     }
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
@@ -68,10 +75,15 @@
     "css-loader": "^7.1.2",
     "electron": "^37.3.0",
     "electron-builder": "^26.7.0",
+    "eslint": "^10.0.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.3.0",
     "html-webpack-plugin": "^5.6.4",
+    "prettier": "^3.8.1",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.2",
     "typescript": "^5.9.2",
+    "typescript-eslint": "^8.56.0",
     "webpack": "^5.105.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,42 +1,42 @@
-import { app, BrowserWindow, ipcMain, Menu, Tray, nativeImage, session } from 'electron';
-import * as path from 'path';
-import { McpdManager as McpdManager } from './mcpd-manager';
-import { setupIPC } from './ipc-handlers';
+import { app, BrowserWindow, Menu, Tray, nativeImage, session } from "electron";
+import * as path from "path";
+import { McpdManager as McpdManager } from "./mcpd-manager";
+import { setupIPC } from "./ipc-handlers";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let mcpdManager: McpdManager;
 
 function createWindow() {
-  const iconPath = path.join(__dirname, 'icon.png');
+  const iconPath = path.join(__dirname, "icon.png");
   const icon = nativeImage.createFromPath(iconPath);
-  
+
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, "preload.js"),
       webSecurity: true,
     },
-    titleBarStyle: 'hiddenInset',
+    titleBarStyle: "hiddenInset",
     icon: icon,
   });
 
-  if (process.env.NODE_ENV === 'development') {
-    mainWindow.loadURL('http://localhost:8080');
+  if (process.env.NODE_ENV === "development") {
+    mainWindow.loadURL("http://localhost:8080");
     mainWindow.webContents.openDevTools();
   } else {
-    mainWindow.loadFile(path.join(__dirname, 'index.html'));
+    mainWindow.loadFile(path.join(__dirname, "index.html"));
   }
 
-  mainWindow.on('closed', () => {
+  mainWindow.on("closed", () => {
     mainWindow = null;
   });
 
   // Prevent window from closing, minimize to tray instead
-  mainWindow.on('close', (event) => {
+  mainWindow.on("close", (event) => {
     if (!(global as any).isQuitting) {
       event.preventDefault();
       mainWindow?.hide();
@@ -45,55 +45,57 @@ function createWindow() {
 }
 
 function createTray() {
-  const iconPath = path.join(__dirname, 'icon.png');
-  const icon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
-  
+  const iconPath = path.join(__dirname, "icon.png");
+  const icon = nativeImage
+    .createFromPath(iconPath)
+    .resize({ width: 16, height: 16 });
+
   tray = new Tray(icon);
-  
+
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: 'Show',
+      label: "Show",
       click: () => {
         mainWindow?.show();
       },
     },
     {
-      label: 'Start Daemon',
+      label: "Start Daemon",
       click: async () => {
         await mcpdManager.startDaemon();
       },
     },
     {
-      label: 'Stop Daemon',
+      label: "Stop Daemon",
       click: async () => {
         await mcpdManager.stopDaemon();
       },
     },
-    { type: 'separator' },
+    { type: "separator" },
     {
-      label: 'Quit',
+      label: "Quit",
       click: async () => {
         (global as any).isQuitting = true;
         try {
           await mcpdManager.stopDaemon();
         } catch (error) {
-          console.error('Error stopping daemon:', error);
+          console.error("Error stopping daemon:", error);
         }
         app.quit();
       },
     },
     {
-      label: 'Force Quit',
+      label: "Force Quit",
       click: () => {
         app.exit(0);
       },
     },
   ]);
 
-  tray.setToolTip('MCPD Client');
+  tray.setToolTip("MCPD Client");
   tray.setContextMenu(contextMenu);
 
-  tray.on('click', () => {
+  tray.on("click", () => {
     mainWindow?.show();
   });
 }
@@ -104,7 +106,7 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  app.on('second-instance', () => {
+  app.on("second-instance", () => {
     // Someone tried to run a second instance, focus our window instead
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
@@ -119,14 +121,14 @@ if (!gotTheLock) {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': [
+          "Content-Security-Policy": [
             "default-src 'self' https://cdn.jsdelivr.net; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net blob:; " +
-            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
-            "font-src 'self' data: https://cdn.jsdelivr.net; " +
-            "worker-src 'self' blob:;"
-          ]
-        }
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net blob:; " +
+              "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
+              "font-src 'self' data: https://cdn.jsdelivr.net; " +
+              "worker-src 'self' blob:;",
+          ],
+        },
       });
     });
 
@@ -137,13 +139,13 @@ if (!gotTheLock) {
   });
 }
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
     app.quit();
   }
 });
 
-app.on('activate', () => {
+app.on("activate", () => {
   if (mainWindow === null) {
     createWindow();
   } else {
@@ -151,16 +153,15 @@ app.on('activate', () => {
   }
 });
 
-app.on('before-quit', async (event) => {
+app.on("before-quit", async (event) => {
   if (mcpdManager) {
     event.preventDefault();
     (global as any).isQuitting = true;
     try {
       await mcpdManager.stopDaemon();
     } catch (error) {
-      console.error('Error stopping daemon during quit:', error);
+      console.error("Error stopping daemon during quit:", error);
     }
     app.exit(0);
   }
 });
-

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,175 +1,192 @@
-import { ipcMain } from 'electron';
-import { McpdManager } from './mcpd-manager';
+import { ipcMain } from "electron";
+import { McpdManager } from "./mcpd-manager";
 
 export function setupIPC(mcpdManager: McpdManager) {
   // Test handler to verify IPC is working
-  ipcMain.handle('test:ping', async () => {
-    console.log('[Main] test:ping received');
-    return 'pong';
+  ipcMain.handle("test:ping", async () => {
+    console.log("[Main] test:ping received");
+    return "pong";
   });
-  
+
   // Daemon management
-  ipcMain.handle('daemon:start', async () => {
-    console.log('[Main] daemon:start IPC received');
+  ipcMain.handle("daemon:start", async () => {
+    console.log("[Main] daemon:start IPC received");
     try {
       const result = await mcpdManager.startDaemon();
-      console.log('[Main] daemon:start result:', result);
+      console.log("[Main] daemon:start result:", result);
       return result;
     } catch (error: any) {
-      console.error('[Main] daemon:start error:', error);
+      console.error("[Main] daemon:start error:", error);
       throw error;
     }
   });
 
-  ipcMain.handle('daemon:stop', async () => {
-    console.log('[Main] daemon:stop IPC received');
+  ipcMain.handle("daemon:stop", async () => {
+    console.log("[Main] daemon:stop IPC received");
     return await mcpdManager.stopDaemon();
   });
 
-  ipcMain.handle('daemon:status', async () => {
-    console.log('[Main] daemon:status IPC received');
+  ipcMain.handle("daemon:status", async () => {
+    console.log("[Main] daemon:status IPC received");
     const status = await mcpdManager.getStatus();
-    console.log('[Main] daemon:status result:', status);
+    console.log("[Main] daemon:status result:", status);
     return status;
   });
 
-  ipcMain.handle('daemon:logs', async (_, lines: number = 100) => {
+  ipcMain.handle("daemon:logs", async (_, lines: number = 100) => {
     return await mcpdManager.getLogs(lines);
   });
 
   // Server management
-  ipcMain.handle('servers:list', async () => {
+  ipcMain.handle("servers:list", async () => {
     const serverNames = await mcpdManager.getServers();
     const configuredServers = await mcpdManager.getConfiguredServers();
     const servers = [];
-    
+
     for (const name of serverNames) {
-      const configServer = configuredServers.find(s => s.name === name);
+      const configServer = configuredServers.find((s) => s.name === name);
       servers.push({
         name,
-        package: configServer?.package || '',
+        package: configServer?.package || "",
         tools: [],
-        status: 'running' as const,
-        health: 'healthy' as const,
+        status: "running" as const,
+        health: "healthy" as const,
       });
     }
-    
+
     return servers;
   });
 
-  ipcMain.handle('servers:add', async (_, server: any) => {
-    console.log('[Main] servers:add received:', server);
+  ipcMain.handle("servers:add", async (_, server: any) => {
+    console.log("[Main] servers:add received:", server);
     try {
       const result = await mcpdManager.addServerToConfig(server);
-      console.log('[Main] Server added successfully');
+      console.log("[Main] Server added successfully");
       return result;
     } catch (error: any) {
-      console.error('[Main] Failed to add server:', error);
+      console.error("[Main] Failed to add server:", error);
       throw error;
     }
   });
 
-  ipcMain.handle('servers:remove', async (_, name: string) => {
+  ipcMain.handle("servers:remove", async (_, name: string) => {
     return await mcpdManager.removeServerFromConfig(name);
   });
 
-  ipcMain.handle('servers:search', async (_, query: string) => {
+  ipcMain.handle("servers:search", async (_, query: string) => {
     return await mcpdManager.searchServers(query);
   });
 
-  ipcMain.handle('servers:tools', async (_, name: string) => {
+  ipcMain.handle("servers:tools", async (_, name: string) => {
     return await mcpdManager.getServerTools(name);
   });
 
   // Tool execution
-  ipcMain.handle('tool:call', async (_, server: string, tool: string, args: any) => {
-    return await mcpdManager.callTool(server, tool, args);
-  });
+  ipcMain.handle(
+    "tool:call",
+    async (_, server: string, tool: string, args: any) => {
+      return await mcpdManager.callTool(server, tool, args);
+    },
+  );
 
   // Configuration
-  ipcMain.handle('config:load', async () => {
+  ipcMain.handle("config:load", async () => {
     return await mcpdManager.loadConfig();
   });
 
-  ipcMain.handle('config:save', async (_, content: string) => {
+  ipcMain.handle("config:save", async (_, content: string) => {
     return await mcpdManager.saveConfig(content);
   });
 
-  ipcMain.handle('config:export', async () => {
+  ipcMain.handle("config:export", async () => {
     const config = await mcpdManager.loadConfig();
     return JSON.stringify(config, null, 2);
   });
 
   // Connect functionality - simplified one-click setup using mcpd-proxy.
-  ipcMain.handle('connect:setup-claude', async (_, serverName: string) => {
-    const fs = require('fs');
-    const path = require('path');
-    const os = require('os');
+  ipcMain.handle("connect:setup-claude", async (_, serverName: string) => {
+    const fs = require("fs");
+    const path = require("path");
+    const os = require("os");
 
     // Claude Desktop config path.
-    const configPath = path.join(os.homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+    const configPath = path.join(
+      os.homedir(),
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude_desktop_config.json",
+    );
 
     // Read existing config or create new one.
     let config: any = {};
     if (fs.existsSync(configPath)) {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     }
 
     // Configure mcpd-proxy as the STDIO bridge for Claude Desktop.
     if (!config.mcpServers) config.mcpServers = {};
     config.mcpServers[`mcpd-${serverName}`] = {
-      command: 'npx',
-      args: ['@mozilla-ai/mcpd-proxy'],
+      command: "npx",
+      args: ["@mozilla-ai/mcpd-proxy"],
       env: {
-        MCPD_ADDR: 'http://localhost:8090'
-      }
+        MCPD_ADDR: "http://localhost:8090",
+      },
     };
 
     // Save the config.
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    return { success: true, message: 'Claude Desktop configured with mcpd-proxy. Please restart Claude Desktop.' };
+    return {
+      success: true,
+      message:
+        "Claude Desktop configured with mcpd-proxy. Please restart Claude Desktop.",
+    };
   });
 
-  ipcMain.handle('connect:setup-http', async (_, serverName: string) => {
+  ipcMain.handle("connect:setup-http", async (_, serverName: string) => {
     // The mcpd daemon exposes an HTTP API directly on port 8090.
     // No separate gateway process is needed.
     return {
       success: true,
       url: `http://localhost:8090/api/v1/servers/${serverName}/tools`,
-      message: 'Use the mcpd HTTP API directly at http://localhost:8090. For STDIO-based IDE connections, use npx @mozilla-ai/mcpd-proxy.'
+      message:
+        "Use the mcpd HTTP API directly at http://localhost:8090. For STDIO-based IDE connections, use npx @mozilla-ai/mcpd-proxy.",
     };
   });
 
-  ipcMain.handle('connect:setup-cursor', async (_, serverName: string) => {
-    const fs = require('fs');
-    const path = require('path');
-    const os = require('os');
+  ipcMain.handle("connect:setup-cursor", async (_, serverName: string) => {
+    const fs = require("fs");
+    const path = require("path");
+    const os = require("os");
 
     // Cursor MCP config path.
-    const configPath = path.join(os.homedir(), '.cursor', 'mcp.json');
+    const configPath = path.join(os.homedir(), ".cursor", "mcp.json");
 
     // Read existing config or create new one.
     let config: any = {};
     if (fs.existsSync(configPath)) {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     }
 
     // Configure mcpd-proxy as the STDIO bridge for Cursor.
     if (!config.mcpServers) config.mcpServers = {};
     config.mcpServers[`mcpd-${serverName}`] = {
-      command: 'npx',
-      args: ['@mozilla-ai/mcpd-proxy'],
+      command: "npx",
+      args: ["@mozilla-ai/mcpd-proxy"],
       env: {
-        MCPD_ADDR: 'http://localhost:8090'
-      }
+        MCPD_ADDR: "http://localhost:8090",
+      },
     };
 
     // Save the config.
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
-    return { success: true, message: 'Cursor configured with mcpd-proxy. Please restart Cursor.' };
+    return {
+      success: true,
+      message: "Cursor configured with mcpd-proxy. Please restart Cursor.",
+    };
   });
 }

--- a/src/main/mcpd-manager.ts
+++ b/src/main/mcpd-manager.ts
@@ -1,10 +1,10 @@
-import { spawn, ChildProcess } from 'child_process';
-import * as path from 'path';
-import * as fs from 'fs';
-import { McpdClient } from '@mozilla-ai/mcpd';
-import * as TOML from '@iarna/toml';
-import { app } from 'electron';
-import { DaemonStatus, MCPTool } from '@shared/types';
+import { spawn, ChildProcess } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+import { McpdClient } from "@mozilla-ai/mcpd";
+import * as TOML from "@iarna/toml";
+import { app } from "electron";
+import { DaemonStatus, MCPTool } from "@shared/types";
 
 export class McpdManager {
   private daemonProcess: ChildProcess | null = null;
@@ -15,14 +15,14 @@ export class McpdManager {
 
   constructor() {
     this.mcpdClient = new McpdClient({
-      apiEndpoint: 'http://localhost:8090',
+      apiEndpoint: "http://localhost:8090",
       timeout: 10000,
     });
 
     // Use proper user data directory for config and logs.
-    const userDataPath = app.getPath('userData');
-    this.logPath = path.join(userDataPath, 'mcpd.log');
-    this.configPath = path.join(userDataPath, '.mcpd.toml');
+    const userDataPath = app.getPath("userData");
+    this.logPath = path.join(userDataPath, "mcpd.log");
+    this.configPath = path.join(userDataPath, ".mcpd.toml");
 
     // Find mcpd binary path.
     this.mcpdPath = this.findMcpdPath();
@@ -42,12 +42,17 @@ export class McpdManager {
 
     // First check if daemon is already running.
     const currentStatus = await this.getStatus();
-    logs.push(`[${this.constructor.name}] Current daemon status: ${JSON.stringify(currentStatus)}`);
-    console.log(`[${this.constructor.name}] Current daemon status:`, currentStatus);
+    logs.push(
+      `[${this.constructor.name}] Current daemon status: ${JSON.stringify(currentStatus)}`,
+    );
+    console.log(
+      `[${this.constructor.name}] Current daemon status:`,
+      currentStatus,
+    );
 
     if (currentStatus.running) {
-      logs.push('Daemon already running, connecting to existing instance');
-      console.log('Daemon already running, connecting to existing instance');
+      logs.push("Daemon already running, connecting to existing instance");
+      console.log("Daemon already running, connecting to existing instance");
       return currentStatus;
     }
 
@@ -60,8 +65,8 @@ export class McpdManager {
       logs.push(`[${this.constructor.name}] Starting daemon promise...`);
 
       // Validate mcpd exists.
-      if (this.mcpdPath !== 'mcpd' && !fs.existsSync(this.mcpdPath)) {
-        const isSystemPath = this.mcpdPath.startsWith('/');
+      if (this.mcpdPath !== "mcpd" && !fs.existsSync(this.mcpdPath)) {
+        const isSystemPath = this.mcpdPath.startsWith("/");
         const errorMsg = isSystemPath
           ? `mcpd binary not found at ${this.mcpdPath}. This should not happen as mcpd is bundled with the app. Please report this issue.`
           : `mcpd binary not found at ${this.mcpdPath}. Please install mcpd using: brew install --cask mozilla-ai/tap/mcpd`;
@@ -71,8 +76,13 @@ export class McpdManager {
         return;
       }
 
-      console.log(`[${this.constructor.name}] mcpd binary found at:`, this.mcpdPath);
-      logs.push(`[${this.constructor.name}] mcpd binary found at: ${this.mcpdPath}`);
+      console.log(
+        `[${this.constructor.name}] mcpd binary found at:`,
+        this.mcpdPath,
+      );
+      logs.push(
+        `[${this.constructor.name}] mcpd binary found at: ${this.mcpdPath}`,
+      );
 
       // Check if config exists, if not create it.
       if (!fs.existsSync(this.configPath)) {
@@ -80,72 +90,83 @@ export class McpdManager {
       }
 
       console.log(`[${this.constructor.name}] Spawning daemon with args:`, [
-        'daemon',
-        '--dev',
-        '--log-level=DEBUG',
+        "daemon",
+        "--dev",
+        "--log-level=DEBUG",
         `--log-path=${this.logPath}`,
-        `--config-file=${this.configPath}`
+        `--config-file=${this.configPath}`,
       ]);
 
       try {
         // Ensure PATH includes common locations for node/npm/npx.
-        const envPath = process.env.PATH || '';
+        const envPath = process.env.PATH || "";
         const additionalPaths = [
-          '/usr/local/bin',
-          '/opt/homebrew/bin',
-          '/usr/bin',
-          '/bin',
-          '/usr/sbin',
-          '/sbin',
+          "/usr/local/bin",
+          "/opt/homebrew/bin",
+          "/usr/bin",
+          "/bin",
+          "/usr/sbin",
+          "/sbin",
           `${process.env.HOME}/.npm/bin`,
           `${process.env.HOME}/.local/bin`,
-          '/usr/local/opt/node/bin',
-          '/opt/homebrew/opt/node/bin',
+          "/usr/local/opt/node/bin",
+          "/opt/homebrew/opt/node/bin",
           `${process.env.HOME}/.nvm/versions/node/v18.0.0/bin`,
           `${process.env.HOME}/.nvm/versions/node/v20.0.0/bin`,
         ];
 
         // Try to find node installation dynamically.
         try {
-          const { execSync } = require('child_process');
-          const nodePath = execSync('which node', { encoding: 'utf-8' }).trim();
+          const { execSync } = require("child_process");
+          const nodePath = execSync("which node", { encoding: "utf-8" }).trim();
           if (nodePath) {
             const nodeDir = path.dirname(nodePath);
             additionalPaths.push(nodeDir);
           }
-        } catch (e) {
+        } catch {
           // Ignore if we can't find node.
         }
 
         // Combine paths, removing duplicates.
-        const pathSet = new Set(envPath.split(':').filter(Boolean));
-        additionalPaths.forEach(p => pathSet.add(p));
-        const fullPath = Array.from(pathSet).join(':');
+        const pathSet = new Set(envPath.split(":").filter(Boolean));
+        additionalPaths.forEach((p) => pathSet.add(p));
+        const fullPath = Array.from(pathSet).join(":");
 
-        this.daemonProcess = spawn(this.mcpdPath, [
-          'daemon',
-          '--dev',
-          '--log-level=DEBUG',
-          `--log-path=${this.logPath}`,
-          `--config-file=${this.configPath}`
-        ], {
-          cwd: app.getPath('userData'),
-          env: {
-            ...process.env,
-            PATH: fullPath,
-            NODE_PATH: '/usr/local/lib/node_modules:/opt/homebrew/lib/node_modules'
+        this.daemonProcess = spawn(
+          this.mcpdPath,
+          [
+            "daemon",
+            "--dev",
+            "--log-level=DEBUG",
+            `--log-path=${this.logPath}`,
+            `--config-file=${this.configPath}`,
+          ],
+          {
+            cwd: app.getPath("userData"),
+            env: {
+              ...process.env,
+              PATH: fullPath,
+              NODE_PATH:
+                "/usr/local/lib/node_modules:/opt/homebrew/lib/node_modules",
+            },
+            detached: false,
           },
-          detached: false,
-        });
+        );
 
-        console.log(`[${this.constructor.name}] Daemon process spawned, pid:`, this.daemonProcess.pid);
+        console.log(
+          `[${this.constructor.name}] Daemon process spawned, pid:`,
+          this.daemonProcess.pid,
+        );
       } catch (spawnError) {
-        console.error(`[${this.constructor.name}] Failed to spawn daemon:`, spawnError);
+        console.error(
+          `[${this.constructor.name}] Failed to spawn daemon:`,
+          spawnError,
+        );
         reject(new Error(`Failed to spawn daemon: ${spawnError}`));
         return;
       }
 
-      let errorOutput = '';
+      let errorOutput = "";
 
       // Add a flag to track if we've already resolved/rejected.
       let hasResolved = false;
@@ -154,14 +175,16 @@ export class McpdManager {
       const absoluteTimeout = setTimeout(() => {
         if (!hasResolved) {
           hasResolved = true;
-          console.error(`[${this.constructor.name}] Daemon start absolute timeout reached`);
-          const errorMsg = `Daemon failed to start within 8 seconds. Path: ${this.mcpdPath}, Config: ${this.configPath}, Error output: ${errorOutput || 'none'}`;
+          console.error(
+            `[${this.constructor.name}] Daemon start absolute timeout reached`,
+          );
+          const errorMsg = `Daemon failed to start within 8 seconds. Path: ${this.mcpdPath}, Config: ${this.configPath}, Error output: ${errorOutput || "none"}`;
           reject(new Error(errorMsg));
         }
       }, 8000);
 
-      this.daemonProcess.on('error', (error) => {
-        console.error('Failed to start mcpd daemon:', error);
+      this.daemonProcess.on("error", (error) => {
+        console.error("Failed to start mcpd daemon:", error);
         this.daemonProcess = null;
         if (!hasResolved) {
           hasResolved = true;
@@ -170,17 +193,17 @@ export class McpdManager {
         }
       });
 
-      this.daemonProcess.stdout?.on('data', (data) => {
+      this.daemonProcess.stdout?.on("data", (data) => {
         console.log(`mcpd stdout: ${data}`);
       });
 
-      this.daemonProcess.stderr?.on('data', (data) => {
+      this.daemonProcess.stderr?.on("data", (data) => {
         const output = data.toString();
         console.error(`mcpd stderr: ${output}`);
         errorOutput += output;
 
         // Check for port already in use error.
-        if (output.includes('address already in use')) {
+        if (output.includes("address already in use")) {
           this.daemonProcess?.kill();
           this.daemonProcess = null;
 
@@ -191,7 +214,7 @@ export class McpdManager {
             try {
               const status = await this.getStatus();
               if (status.running) {
-                console.log('Connected to existing daemon instance');
+                console.log("Connected to existing daemon instance");
                 if (!hasResolved) {
                   hasResolved = true;
                   clearTimeout(absoluteTimeout);
@@ -201,25 +224,29 @@ export class McpdManager {
                 if (!hasResolved) {
                   hasResolved = true;
                   clearTimeout(absoluteTimeout);
-                  reject(new Error('Port 8090 is in use but cannot connect to daemon'));
+                  reject(
+                    new Error(
+                      "Port 8090 is in use but cannot connect to daemon",
+                    ),
+                  );
                 }
               }
-            } catch (error) {
+            } catch {
               if (!hasResolved) {
                 hasResolved = true;
                 clearTimeout(absoluteTimeout);
-                reject(new Error('Port 8090 is in use by another application'));
+                reject(new Error("Port 8090 is in use by another application"));
               }
             }
           }, 500);
         }
       });
 
-      this.daemonProcess.on('exit', (code) => {
+      this.daemonProcess.on("exit", (code) => {
         console.log(`mcpd daemon exited with code ${code}`);
         this.daemonProcess = null;
 
-        if (errorOutput.includes('address already in use')) {
+        if (errorOutput.includes("address already in use")) {
           // Already handled above.
           return;
         }
@@ -238,12 +265,16 @@ export class McpdManager {
           if (status.running) {
             hasResolved = true;
             clearTimeout(absoluteTimeout);
-            console.log(`[${this.constructor.name}] Daemon started successfully`);
+            console.log(
+              `[${this.constructor.name}] Daemon started successfully`,
+            );
             resolve(status);
           } else if (!errorOutput) {
             hasResolved = true;
             clearTimeout(absoluteTimeout);
-            reject(new Error('Daemon failed to start - not running after 5 seconds'));
+            reject(
+              new Error("Daemon failed to start - not running after 5 seconds"),
+            );
           }
         } catch (error) {
           if (!errorOutput && !hasResolved) {
@@ -259,18 +290,18 @@ export class McpdManager {
   async stopDaemon(): Promise<void> {
     if (this.daemonProcess) {
       return new Promise((resolve) => {
-        this.daemonProcess!.on('exit', () => {
+        this.daemonProcess!.on("exit", () => {
           this.daemonProcess = null;
           resolve();
         });
-        this.daemonProcess!.kill('SIGTERM');
+        this.daemonProcess!.kill("SIGTERM");
       });
     } else {
       // Try to stop external daemon using pkill.
       return new Promise((resolve, reject) => {
-        const pkill = spawn('pkill', ['-f', 'mcpd daemon']);
+        const pkill = spawn("pkill", ["-f", "mcpd daemon"]);
 
-        pkill.on('exit', (code) => {
+        pkill.on("exit", (code) => {
           // pkill returns 0 if processes were found and killed, 1 if none found.
           if (code === 0 || code === 1) {
             resolve();
@@ -279,8 +310,8 @@ export class McpdManager {
           }
         });
 
-        pkill.on('error', (error) => {
-          console.error('Failed to execute pkill:', error);
+        pkill.on("error", (error) => {
+          console.error("Failed to execute pkill:", error);
           // Fallback: just resolve as we might not have pkill on all systems.
           resolve();
         });
@@ -295,20 +326,20 @@ export class McpdManager {
       return {
         running: true,
         pid: this.daemonProcess?.pid,
-        apiUrl: 'http://localhost:8090',
+        apiUrl: "http://localhost:8090",
         logPath: this.logPath,
       };
-    } catch (error) {
+    } catch {
       // If health check fails, try listing servers as a fallback.
       try {
         await this.mcpdClient.listServers();
         return {
           running: true,
           pid: this.daemonProcess?.pid,
-          apiUrl: 'http://localhost:8090',
+          apiUrl: "http://localhost:8090",
           logPath: this.logPath,
         };
-      } catch (fallbackError) {
+      } catch {
         return {
           running: false,
           logPath: this.logPath,
@@ -321,7 +352,7 @@ export class McpdManager {
     try {
       return await this.mcpdClient.listServers();
     } catch (error) {
-      console.error('Failed to get servers:', error);
+      console.error("Failed to get servers:", error);
       return [];
     }
   }
@@ -329,7 +360,7 @@ export class McpdManager {
   async getServerTools(serverName: string): Promise<MCPTool[]> {
     try {
       const tools = await this.mcpdClient.servers[serverName].getTools();
-      return tools.map(tool => ({
+      return tools.map((tool) => ({
         name: tool.name,
         description: tool.description,
         inputSchema: tool.inputSchema,
@@ -349,13 +380,17 @@ export class McpdManager {
     }
   }
 
-  async addServer(name: string, packageName: string): Promise<void> {
+  async addServer(name: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const proc = spawn(this.mcpdPath, ['add', name, `--config-file=${this.configPath}`], {
-        cwd: app.getPath('userData'),
-      });
+      const proc = spawn(
+        this.mcpdPath,
+        ["add", name, `--config-file=${this.configPath}`],
+        {
+          cwd: app.getPath("userData"),
+        },
+      );
 
-      proc.on('exit', (code) => {
+      proc.on("exit", (code) => {
         if (code === 0) {
           resolve();
         } else {
@@ -367,11 +402,15 @@ export class McpdManager {
 
   async removeServer(name: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const proc = spawn(this.mcpdPath, ['remove', name, `--config-file=${this.configPath}`], {
-        cwd: app.getPath('userData'),
-      });
+      const proc = spawn(
+        this.mcpdPath,
+        ["remove", name, `--config-file=${this.configPath}`],
+        {
+          cwd: app.getPath("userData"),
+        },
+      );
 
-      proc.on('exit', (code) => {
+      proc.on("exit", (code) => {
         if (code === 0) {
           resolve();
         } else {
@@ -386,21 +425,21 @@ export class McpdManager {
       return [];
     }
 
-    const content = fs.readFileSync(this.logPath, 'utf-8');
-    const allLines = content.split('\n');
+    const content = fs.readFileSync(this.logPath, "utf-8");
+    const allLines = content.split("\n");
     return allLines.slice(-lines);
   }
 
   private initConfig(): void {
-    const initialConfig = 'servers = []';
+    const initialConfig = "servers = []";
     fs.writeFileSync(this.configPath, initialConfig);
   }
 
   async loadConfig(): Promise<any> {
     if (!fs.existsSync(this.configPath)) {
-      return { servers: [], content: 'servers = []' };
+      return { servers: [], content: "servers = []" };
     }
-    const content = fs.readFileSync(this.configPath, 'utf-8');
+    const content = fs.readFileSync(this.configPath, "utf-8");
     return { content };
   }
 
@@ -408,23 +447,33 @@ export class McpdManager {
     fs.writeFileSync(this.configPath, content);
   }
 
-  async searchServers(query: string = '*'): Promise<any[]> {
-    return new Promise((resolve, reject) => {
-      const proc = spawn(this.mcpdPath, ['search', query, '--format', 'json', `--config-file=${this.configPath}`], {
-        cwd: app.getPath('userData'),
-      });
+  async searchServers(query: string = "*"): Promise<any[]> {
+    return new Promise((resolve) => {
+      const proc = spawn(
+        this.mcpdPath,
+        [
+          "search",
+          query,
+          "--format",
+          "json",
+          `--config-file=${this.configPath}`,
+        ],
+        {
+          cwd: app.getPath("userData"),
+        },
+      );
 
-      let output = '';
-      proc.stdout?.on('data', (data) => {
+      let output = "";
+      proc.stdout?.on("data", (data) => {
         output += data.toString();
       });
 
-      proc.on('exit', (code) => {
+      proc.on("exit", (code) => {
         if (code === 0) {
           try {
             const results = JSON.parse(output);
             resolve(results);
-          } catch (error) {
+          } catch {
             resolve([]);
           }
         } else {
@@ -443,11 +492,17 @@ export class McpdManager {
     requiredArgsPositional?: string[];
     requiredArgsBool?: string[];
   }): Promise<void> {
-    console.log(`[${this.constructor.name}] addServerToConfig called with:`, server);
+    console.log(
+      `[${this.constructor.name}] addServerToConfig called with:`,
+      server,
+    );
 
     // Load existing config.
-    const configContent = fs.readFileSync(this.configPath, 'utf-8');
-    console.log(`[${this.constructor.name}] Current config content:`, configContent);
+    const configContent = fs.readFileSync(this.configPath, "utf-8");
+    console.log(
+      `[${this.constructor.name}] Current config content:`,
+      configContent,
+    );
     const config = TOML.parse(configContent) as any;
 
     // Ensure servers array exists.
@@ -476,19 +531,22 @@ export class McpdManager {
     // Handle arguments — mcpd expects args as an array with separate elements.
     if (server.requiredArgs && server.requiredArgs.length > 0) {
       const args: string[] = [];
-      server.requiredArgs.forEach(arg => {
+      server.requiredArgs.forEach((arg) => {
         // Split --key=value into ["--key", "value"].
-        if (arg.includes('=')) {
-          const [key, ...valueParts] = arg.split('=');
+        if (arg.includes("=")) {
+          const [key, ...valueParts] = arg.split("=");
           args.push(key);
-          args.push(valueParts.join('='));
+          args.push(valueParts.join("="));
         } else {
           args.push(arg);
         }
       });
       newServer.args = args;
     }
-    if (server.requiredArgsPositional && server.requiredArgsPositional.length > 0) {
+    if (
+      server.requiredArgsPositional &&
+      server.requiredArgsPositional.length > 0
+    ) {
       newServer.required_args_positional = server.requiredArgsPositional;
     }
     if (server.requiredArgsBool && server.requiredArgsBool.length > 0) {
@@ -503,14 +561,19 @@ export class McpdManager {
     const tomlString = TOML.stringify(config);
     console.log(`[${this.constructor.name}] Writing new config:`, tomlString);
     fs.writeFileSync(this.configPath, tomlString);
-    console.log(`[${this.constructor.name}] Config written successfully to:`, this.configPath);
+    console.log(
+      `[${this.constructor.name}] Config written successfully to:`,
+      this.configPath,
+    );
 
     // Restart daemon to pick up new configuration.
-    console.log(`[${this.constructor.name}] Restarting daemon to load new server...`);
+    console.log(
+      `[${this.constructor.name}] Restarting daemon to load new server...`,
+    );
     const wasRunning = await this.getStatus();
     if (wasRunning.running) {
       await this.stopDaemon();
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       await this.startDaemon();
       console.log(`[${this.constructor.name}] Daemon restarted successfully`);
     }
@@ -518,11 +581,11 @@ export class McpdManager {
 
   async removeServerFromConfig(name: string): Promise<void> {
     // Load existing config.
-    const configContent = fs.readFileSync(this.configPath, 'utf-8');
+    const configContent = fs.readFileSync(this.configPath, "utf-8");
     const config = TOML.parse(configContent) as any;
 
     if (!config.servers) {
-      throw new Error('No servers configured');
+      throw new Error("No servers configured");
     }
 
     // Filter out the server.
@@ -538,11 +601,13 @@ export class McpdManager {
     fs.writeFileSync(this.configPath, tomlString);
 
     // Restart daemon to pick up configuration changes.
-    console.log(`[${this.constructor.name}] Restarting daemon to reload configuration...`);
+    console.log(
+      `[${this.constructor.name}] Restarting daemon to reload configuration...`,
+    );
     const wasRunning = await this.getStatus();
     if (wasRunning.running) {
       await this.stopDaemon();
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       await this.startDaemon();
       console.log(`[${this.constructor.name}] Daemon restarted successfully`);
     }
@@ -553,7 +618,7 @@ export class McpdManager {
       return [];
     }
 
-    const configContent = fs.readFileSync(this.configPath, 'utf-8');
+    const configContent = fs.readFileSync(this.configPath, "utf-8");
     const config = TOML.parse(configContent) as any;
     return config.servers || [];
   }
@@ -561,9 +626,9 @@ export class McpdManager {
   private findMcpdPath(): string {
     // First priority: Check for existing system installation (for developers).
     const systemPaths = [
-      '/opt/homebrew/bin/mcpd',
-      '/usr/local/bin/mcpd',
-      '/usr/bin/mcpd',
+      "/opt/homebrew/bin/mcpd",
+      "/usr/local/bin/mcpd",
+      "/usr/bin/mcpd",
     ];
 
     for (const mcpdPath of systemPaths) {
@@ -572,7 +637,7 @@ export class McpdManager {
           console.log(`Found existing mcpd installation at: ${mcpdPath}`);
           return mcpdPath;
         }
-      } catch (error) {
+      } catch {
         // Continue checking.
       }
     }
@@ -584,8 +649,10 @@ export class McpdManager {
       return bundledPath;
     }
 
-    console.warn('mcpd not found in system paths or bundled, falling back to PATH lookup');
-    return 'mcpd';
+    console.warn(
+      "mcpd not found in system paths or bundled, falling back to PATH lookup",
+    );
+    return "mcpd";
   }
 
   private getBundledMcpdPath(): string | null {
@@ -593,26 +660,30 @@ export class McpdManager {
       // Determine platform-specific binary name.
       const platform = process.platform;
       const arch = process.arch;
-      let binaryName = 'mcpd';
+      let binaryName = "mcpd";
 
-      if (platform === 'darwin') {
-        binaryName = arch === 'arm64' ? 'mcpd-darwin-arm64' : 'mcpd-darwin-x64';
-      } else if (platform === 'win32') {
-        binaryName = 'mcpd.exe';
-      } else if (platform === 'linux') {
-        binaryName = 'mcpd-linux';
+      if (platform === "darwin") {
+        binaryName = arch === "arm64" ? "mcpd-darwin-arm64" : "mcpd-darwin-x64";
+      } else if (platform === "win32") {
+        binaryName = "mcpd.exe";
+      } else if (platform === "linux") {
+        binaryName = "mcpd-linux";
       }
 
       // In development, look in dist/resources.
-      const devPath = path.join(__dirname, 'resources', binaryName);
+      const devPath = path.join(__dirname, "resources", binaryName);
       if (fs.existsSync(devPath)) {
         console.log(`Found bundled mcpd in dev path: ${devPath}`);
         return devPath;
       }
 
       // In packaged app, check if we have process.resourcesPath.
-      if (typeof process.resourcesPath !== 'undefined') {
-        const prodPath = path.join(process.resourcesPath, 'resources', binaryName);
+      if (typeof process.resourcesPath !== "undefined") {
+        const prodPath = path.join(
+          process.resourcesPath,
+          "resources",
+          binaryName,
+        );
         if (fs.existsSync(prodPath)) {
           console.log(`Found bundled mcpd in prod path: ${prodPath}`);
           return prodPath;
@@ -624,20 +695,32 @@ export class McpdManager {
           return altProdPath;
         }
 
-        const asarPath = path.join(process.resourcesPath, 'app.asar', 'dist', 'resources', binaryName);
+        const asarPath = path.join(
+          process.resourcesPath,
+          "app.asar",
+          "dist",
+          "resources",
+          binaryName,
+        );
         if (fs.existsSync(asarPath)) {
           console.log(`Found bundled mcpd in asar path: ${asarPath}`);
           return asarPath;
         }
 
-        console.log(`Bundled mcpd not found in packaged app. Searched paths:`, [prodPath, altProdPath, asarPath]);
+        console.log(`Bundled mcpd not found in packaged app. Searched paths:`, [
+          prodPath,
+          altProdPath,
+          asarPath,
+        ]);
       } else {
-        console.log(`process.resourcesPath not available, app might not be packaged`);
+        console.log(
+          `process.resourcesPath not available, app might not be packaged`,
+        );
       }
 
       return null;
     } catch (error) {
-      console.error('Error finding bundled mcpd:', error);
+      console.error("Error finding bundled mcpd:", error);
       return null;
     }
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,61 +1,63 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer } from "electron";
 
-console.log('[Preload] Starting preload script');
+console.log("[Preload] Starting preload script");
 
 try {
-  contextBridge.exposeInMainWorld('electronAPI', {
+  contextBridge.exposeInMainWorld("electronAPI", {
     // Daemon management
     startDaemon: () => {
-      console.log('[Preload] startDaemon called');
-      return ipcRenderer.invoke('daemon:start');
+      console.log("[Preload] startDaemon called");
+      return ipcRenderer.invoke("daemon:start");
     },
     stopDaemon: () => {
-      console.log('[Preload] stopDaemon called');
-      return ipcRenderer.invoke('daemon:stop');
+      console.log("[Preload] stopDaemon called");
+      return ipcRenderer.invoke("daemon:stop");
     },
     getDaemonStatus: () => {
-      console.log('[Preload] getDaemonStatus called');
-      return ipcRenderer.invoke('daemon:status');
+      console.log("[Preload] getDaemonStatus called");
+      return ipcRenderer.invoke("daemon:status");
     },
-    getDaemonLogs: (lines?: number) => ipcRenderer.invoke('daemon:logs', lines),
+    getDaemonLogs: (lines?: number) => ipcRenderer.invoke("daemon:logs", lines),
 
     // Server management
-    listServers: () => ipcRenderer.invoke('servers:list'),
-    addServer: (server: any) => 
-      ipcRenderer.invoke('servers:add', server),
-    removeServer: (name: string) => ipcRenderer.invoke('servers:remove', name),
-    searchServers: (query: string) => ipcRenderer.invoke('servers:search', query),
-    getServerTools: (name: string) => ipcRenderer.invoke('servers:tools', name),
+    listServers: () => ipcRenderer.invoke("servers:list"),
+    addServer: (server: any) => ipcRenderer.invoke("servers:add", server),
+    removeServer: (name: string) => ipcRenderer.invoke("servers:remove", name),
+    searchServers: (query: string) =>
+      ipcRenderer.invoke("servers:search", query),
+    getServerTools: (name: string) => ipcRenderer.invoke("servers:tools", name),
 
     // Tool execution
-    callTool: (server: string, tool: string, args: any) => 
-      ipcRenderer.invoke('tool:call', server, tool, args),
+    callTool: (server: string, tool: string, args: any) =>
+      ipcRenderer.invoke("tool:call", server, tool, args),
 
     // Configuration
-    loadConfig: () => ipcRenderer.invoke('config:load'),
-    saveConfig: (content: string) => ipcRenderer.invoke('config:save', content),
-    exportConfig: () => ipcRenderer.invoke('config:export'),
-    
+    loadConfig: () => ipcRenderer.invoke("config:load"),
+    saveConfig: (content: string) => ipcRenderer.invoke("config:save", content),
+    exportConfig: () => ipcRenderer.invoke("config:export"),
+
     // Connect functionality - one-click setup
-    setupClaude: (serverName: string) => ipcRenderer.invoke('connect:setup-claude', serverName),
-    setupHTTP: (serverName: string) => ipcRenderer.invoke('connect:setup-http', serverName),
-    setupCursor: (serverName: string) => ipcRenderer.invoke('connect:setup-cursor', serverName),
-    
+    setupClaude: (serverName: string) =>
+      ipcRenderer.invoke("connect:setup-claude", serverName),
+    setupHTTP: (serverName: string) =>
+      ipcRenderer.invoke("connect:setup-http", serverName),
+    setupCursor: (serverName: string) =>
+      ipcRenderer.invoke("connect:setup-cursor", serverName),
+
     // Test function
     test: () => {
-      console.log('[Preload] test function called');
-      return 'Preload is working!';
-    }
+      console.log("[Preload] test function called");
+      return "Preload is working!";
+    },
   });
-  
-  console.log('[Preload] electronAPI exposed successfully');
-  
+
+  console.log("[Preload] electronAPI exposed successfully");
+
   // Also expose a simple test to verify the bridge works
-  contextBridge.exposeInMainWorld('preloadTest', {
+  contextBridge.exposeInMainWorld("preloadTest", {
     isWorking: true,
-    version: '1.0.7'
+    version: "1.0.7",
   });
-  
 } catch (error) {
-  console.error('[Preload] Failed to expose API:', error);
+  console.error("[Preload] Failed to expose API:", error);
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Layout, Menu, Badge, Tooltip } from 'antd';
+import React, { useState, useEffect } from "react";
+import { Layout, Menu, Badge, Tooltip } from "antd";
 import {
   CloudServerOutlined,
   SettingOutlined,
@@ -8,14 +8,14 @@ import {
   FileTextOutlined,
   PoweroffOutlined,
   RocketOutlined,
-} from '@ant-design/icons';
-import Dashboard from './components/Dashboard';
-import ServerManager from './components/ServerManager';
-import ToolExplorer from './components/ToolExplorer';
-import ConfigEditor from './components/ConfigEditor';
-import LogViewer from './components/LogViewer';
-import QuickSetup from './components/QuickSetup';
-import { DaemonStatus } from '@shared/types';
+} from "@ant-design/icons";
+import Dashboard from "./components/Dashboard";
+import ServerManager from "./components/ServerManager";
+import ToolExplorer from "./components/ToolExplorer";
+import ConfigEditor from "./components/ConfigEditor";
+import LogViewer from "./components/LogViewer";
+import QuickSetup from "./components/QuickSetup";
+import { DaemonStatus } from "@shared/types";
 
 const { Header, Sider, Content } = Layout;
 
@@ -35,16 +35,22 @@ declare global {
       loadConfig: () => Promise<any>;
       saveConfig: (content: string) => Promise<void>;
       exportConfig: () => Promise<string>;
-      setupClaude: (serverName: string) => Promise<{ success: boolean; message: string }>;
-      setupHTTP: (serverName: string) => Promise<{ success: boolean; url?: string; message: string }>;
-      setupCursor: (serverName: string) => Promise<{ success: boolean; message: string }>;
+      setupClaude: (
+        serverName: string,
+      ) => Promise<{ success: boolean; message: string }>;
+      setupHTTP: (
+        serverName: string,
+      ) => Promise<{ success: boolean; url?: string; message: string }>;
+      setupCursor: (
+        serverName: string,
+      ) => Promise<{ success: boolean; message: string }>;
     };
   }
 }
 
 const App: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
-  const [selectedMenu, setSelectedMenu] = useState('dashboard');
+  const [selectedMenu, setSelectedMenu] = useState("dashboard");
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>({
     running: false,
   });
@@ -60,88 +66,93 @@ const App: React.FC = () => {
       const status = await window.electronAPI.getDaemonStatus();
       setDaemonStatus(status);
     } catch (error) {
-      console.error('Failed to check daemon status:', error);
+      console.error("Failed to check daemon status:", error);
     }
   };
 
   const testIPC = async () => {
-    console.log('Testing IPC...');
-    console.log('window.electronAPI:', (window as any).electronAPI);
-    console.log('window.preloadTest:', (window as any).preloadTest);
-    
+    console.log("Testing IPC...");
+    console.log("window.electronAPI:", (window as any).electronAPI);
+    console.log("window.preloadTest:", (window as any).preloadTest);
+
     try {
       // Test if preload script ran at all
       const preloadTest = (window as any).preloadTest;
       if (preloadTest) {
-        console.log('Preload test object found:', preloadTest);
+        console.log("Preload test object found:", preloadTest);
       }
-      
+
       // Test if electronAPI exists
       const electronAPI = (window as any).electronAPI;
       if (electronAPI) {
-        console.log('electronAPI found, testing test function...');
+        console.log("electronAPI found, testing test function...");
         if (electronAPI.test) {
           const testResult = electronAPI.test();
-          console.log('electronAPI.test() result:', testResult);
+          console.log("electronAPI.test() result:", testResult);
         }
       } else {
-        console.error('electronAPI not found on window object');
+        console.error("electronAPI not found on window object");
       }
-      
-      const result = electronAPI ? 'electronAPI available' : 'electronAPI not available';
-      console.log('IPC test result:', result);
+
+      const result = electronAPI
+        ? "electronAPI available"
+        : "electronAPI not available";
+      console.log("IPC test result:", result);
     } catch (error) {
-      console.error('IPC test error:', error);
+      console.error("IPC test error:", error);
     }
   };
 
   const toggleDaemon = async () => {
-    console.log('toggleDaemon called, current status:', daemonStatus);
-    
+    console.log("toggleDaemon called, current status:", daemonStatus);
+
     // First test IPC
     await testIPC();
-    
+
     try {
       if (daemonStatus.running) {
-        console.log('Stopping daemon...');
+        console.log("Stopping daemon...");
         await window.electronAPI.stopDaemon();
-        console.log('Daemon stopped');
+        console.log("Daemon stopped");
       } else {
-        console.log('Starting daemon...');
+        console.log("Starting daemon...");
         try {
           // Add a timeout to prevent indefinite hanging
           const startPromise = window.electronAPI.startDaemon();
-          const timeoutPromise = new Promise((_, reject) => 
-            setTimeout(() => reject(new Error('Daemon start timeout after 10 seconds')), 10000)
+          const timeoutPromise = new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("Daemon start timeout after 10 seconds")),
+              10000,
+            ),
           );
-          
+
           const result = await Promise.race([startPromise, timeoutPromise]);
-          console.log('Start daemon result:', result);
+          console.log("Start daemon result:", result);
         } catch (err) {
-          console.error('Failed to start daemon:', err);
+          console.error("Failed to start daemon:", err);
           throw err;
         }
       }
-      console.log('Checking daemon status after toggle...');
+      console.log("Checking daemon status after toggle...");
       await checkDaemonStatus();
     } catch (error) {
-      console.error('Failed to toggle daemon:', error);
+      console.error("Failed to toggle daemon:", error);
     }
   };
 
   const renderContent = () => {
     switch (selectedMenu) {
-      case 'dashboard':
+      case "dashboard":
         return <Dashboard daemonStatus={daemonStatus} />;
-      case 'connect':
+      case "connect":
         return <QuickSetup />;
-      case 'servers':
+      case "servers":
         return <ServerManager />;
-      case 'tools':
+      case "tools":
         return <ToolExplorer />;
-      case 'config':
+      case "config":
         return <ConfigEditor />;
-      case 'logs':
+      case "logs":
         return <LogViewer />;
       default:
         return <Dashboard daemonStatus={daemonStatus} />;
@@ -149,9 +160,11 @@ const App: React.FC = () => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
+    <Layout style={{ minHeight: "100vh" }}>
       <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed}>
-        <div style={{ height: 32, margin: 16, textAlign: 'center', color: '#fff' }}>
+        <div
+          style={{ height: 32, margin: 16, textAlign: "center", color: "#fff" }}
+        >
           {!collapsed && <h3>mcpd Client</h3>}
         </div>
         <Menu
@@ -181,31 +194,40 @@ const App: React.FC = () => {
         </Menu>
       </Sider>
       <Layout>
-        <Header style={{ padding: '0 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <h2 style={{ margin: 0, color: '#fff' }}>
-            {selectedMenu === 'connect' ? 'Connect' : selectedMenu.charAt(0).toUpperCase() + selectedMenu.slice(1)}
+        <Header
+          style={{
+            padding: "0 24px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <h2 style={{ margin: 0, color: "#fff" }}>
+            {selectedMenu === "connect"
+              ? "Connect"
+              : selectedMenu.charAt(0).toUpperCase() + selectedMenu.slice(1)}
           </h2>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
             <Badge
-              status={daemonStatus.running ? 'success' : 'error'}
-              text={daemonStatus.running ? 'Daemon Running' : 'Daemon Stopped'}
-              style={{ color: '#fff' }}
+              status={daemonStatus.running ? "success" : "error"}
+              text={daemonStatus.running ? "Daemon Running" : "Daemon Stopped"}
+              style={{ color: "#fff" }}
             />
-            <Tooltip title={daemonStatus.running ? 'Stop Daemon' : 'Start Daemon'}>
+            <Tooltip
+              title={daemonStatus.running ? "Stop Daemon" : "Start Daemon"}
+            >
               <PoweroffOutlined
                 onClick={toggleDaemon}
                 style={{
                   fontSize: 20,
-                  color: daemonStatus.running ? '#52c41a' : '#ff4d4f',
-                  cursor: 'pointer',
+                  color: daemonStatus.running ? "#52c41a" : "#ff4d4f",
+                  cursor: "pointer",
                 }}
               />
             </Tooltip>
           </div>
         </Header>
-        <Content style={{ margin: 24 }}>
-          {renderContent()}
-        </Content>
+        <Content style={{ margin: 24 }}>{renderContent()}</Content>
       </Layout>
     </Layout>
   );

--- a/src/renderer/components/AddServerModal.tsx
+++ b/src/renderer/components/AddServerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Modal,
   Form,
@@ -8,37 +8,37 @@ import {
   Space,
   Tabs,
   Tag,
-  Alert,
   Checkbox,
   Divider,
   List,
   Typography,
-  Spin,
   message,
   Card,
   Row,
   Col,
   Collapse,
   Empty,
-} from 'antd';
+} from "antd";
 import {
-  SearchOutlined,
-  PlusOutlined,
   CodeOutlined,
   SettingOutlined,
-  InfoCircleOutlined,
   DatabaseOutlined,
   CloudOutlined,
   GithubOutlined,
   MessageOutlined,
   FileOutlined,
   GlobalOutlined,
-} from '@ant-design/icons';
-import MonacoEditor from '@monaco-editor/react';
-import { MCP_SERVERS, MCPServerTemplate, getServersByCategory, searchServers } from '../data/mcp-servers';
+} from "@ant-design/icons";
+import MonacoEditor from "@monaco-editor/react";
+import {
+  MCP_SERVERS,
+  MCPServerTemplate,
+  getServersByCategory,
+  searchServers,
+} from "../data/mcp-servers";
 
 const { TextArea } = Input;
-const { Text, Paragraph, Title } = Typography;
+const { Text, Paragraph } = Typography;
 const { TabPane } = Tabs;
 
 interface AddServerModalProps {
@@ -47,50 +47,37 @@ interface AddServerModalProps {
   onSuccess: () => void;
 }
 
-interface RegistryServer {
-  id: string;
-  name: string;
-  description?: string;
-  license?: string;
-  official?: boolean;
-  categories?: string[];
-  tags?: string[];
-  runtimes?: Array<{
-    runtime: string;
-    package: string;
-    version: string;
-  }>;
-  tools?: string[];
-  environmentVariables?: Array<{
-    name: string;
-    description: string;
-    required: boolean;
-  }>;
-  requiredArgs?: string[];
-}
-
-const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuccess }) => {
+const AddServerModal: React.FC<AddServerModalProps> = ({
+  visible,
+  onClose,
+  onSuccess,
+}) => {
   const [form] = Form.useForm();
-  const [mode, setMode] = useState<'browse' | 'custom'>('browse');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedServer, setSelectedServer] = useState<MCPServerTemplate | null>(null);
-  const [selectedRuntime, setSelectedRuntime] = useState<'npx' | 'uvx' | 'docker'>('npx');
+  const [mode, setMode] = useState<"browse" | "custom">("browse");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedServer, setSelectedServer] =
+    useState<MCPServerTemplate | null>(null);
+  const [selectedRuntime, setSelectedRuntime] = useState<
+    "npx" | "uvx" | "docker"
+  >("npx");
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
-  const [tomlPreview, setTomlPreview] = useState('');
+  const [tomlPreview, setTomlPreview] = useState("");
   const [adding, setAdding] = useState(false);
-  
+
   const serversByCategory = getServersByCategory();
-  const filteredServers = searchQuery ? searchServers(searchQuery) : MCP_SERVERS;
+  const filteredServers = searchQuery
+    ? searchServers(searchQuery)
+    : MCP_SERVERS;
 
   useEffect(() => {
     if (!visible) {
       // Reset state when modal closes
       form.resetFields();
-      setMode('browse');
+      setMode("browse");
       setSelectedServer(null);
       setSelectedTools([]);
-      setSearchQuery('');
-      setTomlPreview('');
+      setSearchQuery("");
+      setTomlPreview("");
     }
   }, [visible, form]);
 
@@ -100,37 +87,38 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
 
   const getCategoryIcon = (category: string) => {
     const icons: Record<string, React.ReactNode> = {
-      'Development': <GithubOutlined />,
-      'Database': <DatabaseOutlined />,
-      'Cloud Storage': <CloudOutlined />,
-      'Communication': <MessageOutlined />,
-      'File Management': <FileOutlined />,
-      'Web & Search': <GlobalOutlined />,
-      'Utilities': <SettingOutlined />,
+      Development: <GithubOutlined />,
+      Database: <DatabaseOutlined />,
+      "Cloud Storage": <CloudOutlined />,
+      Communication: <MessageOutlined />,
+      "File Management": <FileOutlined />,
+      "Web & Search": <GlobalOutlined />,
+      Utilities: <SettingOutlined />,
     };
     return icons[category] || <CodeOutlined />;
   };
 
   const selectServer = (server: MCPServerTemplate) => {
     setSelectedServer(server);
-    
+
     // Determine available runtime
-    const availableRuntimes = Object.keys(server.package).filter(rt => 
-      server.package[rt as keyof typeof server.package]
+    const availableRuntimes = Object.keys(server.package).filter(
+      (rt) => server.package[rt as keyof typeof server.package],
     );
-    
-    let runtime: 'npx' | 'uvx' | 'docker' = 'npx';
+
+    let runtime: "npx" | "uvx" | "docker" = "npx";
     if (availableRuntimes.length > 0) {
-      runtime = availableRuntimes[0] as 'npx' | 'uvx' | 'docker';
+      runtime = availableRuntimes[0] as "npx" | "uvx" | "docker";
       setSelectedRuntime(runtime);
     }
-    
+
     // Auto-select all tools by default
-    setSelectedTools(server.tools.map(t => t.name));
+    setSelectedTools(server.tools.map((t) => t.name));
 
     // Get the package string for the selected runtime WITH runtime prefix
-    const packageString = server.package[runtime as keyof typeof server.package] || '';
-    const fullPackage = packageString ? `${runtime}::${packageString}` : '';
+    const packageString =
+      server.package[runtime as keyof typeof server.package] || "";
+    const fullPackage = packageString ? `${runtime}::${packageString}` : "";
 
     // Pre-fill form with server details
     form.setFieldsValue({
@@ -141,9 +129,9 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
     // Set environment variables if any
     if (server.environmentVariables) {
       const envVars: Record<string, string> = {};
-      server.environmentVariables.forEach(env => {
+      server.environmentVariables.forEach((env) => {
         if (env.required) {
-          envVars[env.name] = '';
+          envVars[env.name] = "";
         }
       });
       form.setFieldsValue({ envVars });
@@ -152,9 +140,9 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
     // Set arguments if any
     if (server.arguments) {
       const args = server.arguments
-        .filter(arg => arg.required)
-        .map(arg => `${arg.name}=${arg.example || ''}`)
-        .join(', ');
+        .filter((arg) => arg.required)
+        .map((arg) => `${arg.name}=${arg.example || ""}`)
+        .join(", ");
       form.setFieldsValue({ args });
     }
   };
@@ -163,45 +151,50 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
     try {
       const values = form.getFieldsValue();
       if (!values.name || !values.package) {
-        setTomlPreview('');
+        setTomlPreview("");
         return;
       }
 
-      let toml = '[[servers]]\n';
+      let toml = "[[servers]]\n";
       toml += `  name = "${values.name}"\n`;
       toml += `  package = "${values.package}"\n`;
-      
+
       if (selectedTools.length > 0) {
-        toml += `  tools = [${selectedTools.map(t => `"${t}"`).join(', ')}]\n`;
+        toml += `  tools = [${selectedTools.map((t) => `"${t}"`).join(", ")}]\n`;
       }
-      
-      if (values.envVars && typeof values.envVars === 'object') {
-        const envVars = Object.keys(values.envVars).filter(key => values.envVars[key]);
+
+      if (values.envVars && typeof values.envVars === "object") {
+        const envVars = Object.keys(values.envVars).filter(
+          (key) => values.envVars[key],
+        );
         if (envVars.length > 0) {
-          toml += `  required_env = [${envVars.map(v => `"${v}"`).join(', ')}]\n`;
+          toml += `  required_env = [${envVars.map((v) => `"${v}"`).join(", ")}]\n`;
         }
       }
-      
+
       if (values.args) {
         let args: string[] = [];
-        if (typeof values.args === 'string') {
+        if (typeof values.args === "string") {
           // Custom mode: comma-separated string
-          args = values.args.split(',').map((a: string) => a.trim()).filter(Boolean);
-        } else if (typeof values.args === 'object') {
+          args = values.args
+            .split(",")
+            .map((a: string) => a.trim())
+            .filter(Boolean);
+        } else if (typeof values.args === "object") {
           // Browse mode: object with argument names as keys
           args = Object.entries(values.args)
-            .filter(([_, value]) => value)
+            .filter(([, value]) => value)
             .map(([key, value]) => `${key}=${value}`);
         }
         if (args.length > 0) {
-          toml += `  required_args = [${args.map((a: string) => `"${a}"`).join(', ')}]\n`;
+          toml += `  required_args = [${args.map((a: string) => `"${a}"`).join(", ")}]\n`;
         }
       }
 
       setTomlPreview(toml);
     } catch (error) {
-      console.error('Error updating TOML preview:', error);
-      setTomlPreview('# Error generating preview');
+      console.error("Error updating TOML preview:", error);
+      setTomlPreview("# Error generating preview");
     }
   };
 
@@ -213,13 +206,16 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
       // Handle arguments - they come as nested object from form
       let requiredArgs: string[] | undefined;
       if (values.args) {
-        if (typeof values.args === 'string') {
+        if (typeof values.args === "string") {
           // Custom mode: comma-separated string
-          requiredArgs = values.args.split(',').map((a: string) => a.trim()).filter(Boolean);
-        } else if (typeof values.args === 'object') {
+          requiredArgs = values.args
+            .split(",")
+            .map((a: string) => a.trim())
+            .filter(Boolean);
+        } else if (typeof values.args === "object") {
           // Browse mode: object with argument names as keys
           requiredArgs = Object.entries(values.args)
-            .filter(([_, value]) => value)
+            .filter(([, value]) => value)
             .map(([key, value]) => `${key}=${value}`);
         }
       }
@@ -228,20 +224,20 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
         name: values.name,
         package: values.package,
         tools: selectedTools,
-        requiredEnv: values.envVars ? 
-          Object.keys(values.envVars).filter(key => values.envVars[key]) : 
-          undefined,
+        requiredEnv: values.envVars
+          ? Object.keys(values.envVars).filter((key) => values.envVars[key])
+          : undefined,
         requiredArgs,
       };
 
-      console.log('Adding server with config:', serverConfig);
+      console.log("Adding server with config:", serverConfig);
       await window.electronAPI.addServer(serverConfig);
       message.success(`Server ${values.name} added successfully`);
       onSuccess();
       onClose();
     } catch (error: any) {
-      console.error('Failed to add server:', error);
-      message.error(error.message || 'Failed to add server');
+      console.error("Failed to add server:", error);
+      message.error(error.message || "Failed to add server");
     } finally {
       setAdding(false);
     }
@@ -260,7 +256,7 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
       {searchQuery && filteredServers.length === 0 ? (
         <Empty description={`No servers found matching "${searchQuery}"`} />
       ) : (
-        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+        <div style={{ maxHeight: 400, overflow: "auto" }}>
           {searchQuery ? (
             // Show filtered results as a flat list
             <List
@@ -269,8 +265,11 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                 <List.Item
                   onClick={() => selectServer(server)}
                   style={{
-                    cursor: 'pointer',
-                    background: selectedServer?.id === server.id ? '#1890ff20' : 'transparent',
+                    cursor: "pointer",
+                    background:
+                      selectedServer?.id === server.id
+                        ? "#1890ff20"
+                        : "transparent",
                     padding: 12,
                     borderRadius: 4,
                     marginBottom: 8,
@@ -287,17 +286,26 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                     }
                     description={
                       <div>
-                        <Paragraph ellipsis={{ rows: 2 }} style={{ marginBottom: 8 }}>
+                        <Paragraph
+                          ellipsis={{ rows: 2 }}
+                          style={{ marginBottom: 8 }}
+                        >
                           {server.description}
                         </Paragraph>
                         <Space wrap size="small">
-                          {server.tools.slice(0, 3).map(tool => (
-                            <Tag key={tool.name} color="geekblue" style={{ fontSize: 11 }}>
+                          {server.tools.slice(0, 3).map((tool) => (
+                            <Tag
+                              key={tool.name}
+                              color="geekblue"
+                              style={{ fontSize: 11 }}
+                            >
                               {tool.name}
                             </Tag>
                           ))}
                           {server.tools.length > 3 && (
-                            <Tag style={{ fontSize: 11 }}>+{server.tools.length - 3} more</Tag>
+                            <Tag style={{ fontSize: 11 }}>
+                              +{server.tools.length - 3} more
+                            </Tag>
                           )}
                         </Space>
                       </div>
@@ -326,8 +334,11 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                       <List.Item
                         onClick={() => selectServer(server)}
                         style={{
-                          cursor: 'pointer',
-                          background: selectedServer?.id === server.id ? '#1890ff20' : 'transparent',
+                          cursor: "pointer",
+                          background:
+                            selectedServer?.id === server.id
+                              ? "#1890ff20"
+                              : "transparent",
                           padding: 12,
                           borderRadius: 4,
                           marginBottom: 8,
@@ -337,22 +348,35 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                           title={
                             <Space>
                               {server.name}
-                              {server.official && <Tag color="blue" style={{ fontSize: 11 }}>Official</Tag>}
+                              {server.official && (
+                                <Tag color="blue" style={{ fontSize: 11 }}>
+                                  Official
+                                </Tag>
+                              )}
                             </Space>
                           }
                           description={
                             <div>
-                              <Paragraph ellipsis={{ rows: 2 }} style={{ marginBottom: 8, fontSize: 13 }}>
+                              <Paragraph
+                                ellipsis={{ rows: 2 }}
+                                style={{ marginBottom: 8, fontSize: 13 }}
+                              >
                                 {server.description}
                               </Paragraph>
                               <Space wrap size="small">
-                                {server.tools.slice(0, 4).map(tool => (
-                                  <Tag key={tool.name} color="geekblue" style={{ fontSize: 11 }}>
+                                {server.tools.slice(0, 4).map((tool) => (
+                                  <Tag
+                                    key={tool.name}
+                                    color="geekblue"
+                                    style={{ fontSize: 11 }}
+                                  >
                                     {tool.name}
                                   </Tag>
                                 ))}
                                 {server.tools.length > 4 && (
-                                  <Tag style={{ fontSize: 11 }}>+{server.tools.length - 4} more</Tag>
+                                  <Tag style={{ fontSize: 11 }}>
+                                    +{server.tools.length - 4} more
+                                  </Tag>
                                 )}
                               </Space>
                             </div>
@@ -374,7 +398,9 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
             <Form.Item
               name="name"
               label="Server Name"
-              rules={[{ required: true, message: 'Please enter a server name' }]}
+              rules={[
+                { required: true, message: "Please enter a server name" },
+              ]}
             >
               <Input placeholder="e.g., github, filesystem" />
             </Form.Item>
@@ -382,7 +408,9 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
             <Form.Item
               name="package"
               label="Package"
-              rules={[{ required: true, message: 'Please select or enter a package' }]}
+              rules={[
+                { required: true, message: "Please select or enter a package" },
+              ]}
             >
               {Object.keys(selectedServer.package).length > 1 ? (
                 <Select
@@ -390,20 +418,25 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                   value={selectedRuntime}
                   onChange={(value) => {
                     setSelectedRuntime(value);
-                    const pkg = selectedServer.package[value as keyof typeof selectedServer.package];
-                    form.setFieldValue('package', `${value}::${pkg}`);
+                    const pkg =
+                      selectedServer.package[
+                        value as keyof typeof selectedServer.package
+                      ];
+                    form.setFieldValue("package", `${value}::${pkg}`);
                   }}
                 >
-                  {Object.entries(selectedServer.package).map(([runtime, pkg]) => (
-                    <Select.Option key={runtime} value={runtime}>
-                      {runtime}: {pkg}
-                    </Select.Option>
-                  ))}
+                  {Object.entries(selectedServer.package).map(
+                    ([runtime, pkg]) => (
+                      <Select.Option key={runtime} value={runtime}>
+                        {runtime}: {pkg}
+                      </Select.Option>
+                    ),
+                  )}
                 </Select>
               ) : (
-                <Input 
+                <Input
                   value={`${selectedRuntime}::${selectedServer.package[selectedRuntime as keyof typeof selectedServer.package]}`}
-                  disabled 
+                  disabled
                 />
               )}
             </Form.Item>
@@ -413,10 +446,10 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
                 <Checkbox.Group
                   value={selectedTools}
                   onChange={setSelectedTools}
-                  style={{ width: '100%' }}
+                  style={{ width: "100%" }}
                 >
                   <Row>
-                    {selectedServer.tools.map(tool => (
+                    {selectedServer.tools.map((tool) => (
                       <Col span={12} key={tool.name}>
                         <Checkbox value={tool.name}>
                           <span title={tool.description}>{tool.name}</span>
@@ -428,50 +461,78 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
               </Form.Item>
             )}
 
-            {selectedServer.environmentVariables && selectedServer.environmentVariables.length > 0 && (
-              <Form.Item label="Environment Variables">
-                {selectedServer.environmentVariables.map(env => (
-                  <Form.Item
-                    key={env.name}
-                    name={['envVars', env.name]}
-                    label={
-                      <Space>
-                        {env.name}
-                        {env.required && <Tag color="red">Required</Tag>}
-                      </Space>
-                    }
-                    help={env.description}
-                    rules={env.required ? [{ required: true, message: `${env.name} is required` }] : []}
-                  >
-                    <Input.Password 
-                      placeholder={env.example ? `e.g., ${env.example}` : `Enter ${env.name}`} 
-                    />
-                  </Form.Item>
-                ))}
-              </Form.Item>
-            )}
+            {selectedServer.environmentVariables &&
+              selectedServer.environmentVariables.length > 0 && (
+                <Form.Item label="Environment Variables">
+                  {selectedServer.environmentVariables.map((env) => (
+                    <Form.Item
+                      key={env.name}
+                      name={["envVars", env.name]}
+                      label={
+                        <Space>
+                          {env.name}
+                          {env.required && <Tag color="red">Required</Tag>}
+                        </Space>
+                      }
+                      help={env.description}
+                      rules={
+                        env.required
+                          ? [
+                              {
+                                required: true,
+                                message: `${env.name} is required`,
+                              },
+                            ]
+                          : []
+                      }
+                    >
+                      <Input.Password
+                        placeholder={
+                          env.example
+                            ? `e.g., ${env.example}`
+                            : `Enter ${env.name}`
+                        }
+                      />
+                    </Form.Item>
+                  ))}
+                </Form.Item>
+              )}
 
-            {selectedServer.arguments && selectedServer.arguments.length > 0 && (
-              <Form.Item label="Arguments">
-                {selectedServer.arguments.map(arg => (
-                  <Form.Item
-                    key={arg.name}
-                    name={['args', arg.name]}
-                    label={
-                      <Space>
-                        {arg.name}
-                        {arg.required && <Tag color="red">Required</Tag>}
-                      </Space>
-                    }
-                    help={arg.description}
-                    rules={arg.required ? [{ required: true, message: `${arg.name} is required` }] : []}
-                    initialValue={arg.example}
-                  >
-                    <Input placeholder={arg.example || `Enter value for ${arg.name}`} />
-                  </Form.Item>
-                ))}
-              </Form.Item>
-            )}
+            {selectedServer.arguments &&
+              selectedServer.arguments.length > 0 && (
+                <Form.Item label="Arguments">
+                  {selectedServer.arguments.map((arg) => (
+                    <Form.Item
+                      key={arg.name}
+                      name={["args", arg.name]}
+                      label={
+                        <Space>
+                          {arg.name}
+                          {arg.required && <Tag color="red">Required</Tag>}
+                        </Space>
+                      }
+                      help={arg.description}
+                      rules={
+                        arg.required
+                          ? [
+                              {
+                                required: true,
+                                message: `${arg.name} is required`,
+                              },
+                            ]
+                          : []
+                      }
+                      initialValue={arg.example}
+                    >
+                      <Input
+                        placeholder={
+                          arg.example || `Enter value for ${arg.name}`
+                        }
+                      />
+                    </Form.Item>
+                  ))}
+                </Form.Item>
+              )}
           </Form>
         </Card>
       )}
@@ -483,7 +544,7 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
       <Form.Item
         name="name"
         label="Server Name"
-        rules={[{ required: true, message: 'Please enter a server name' }]}
+        rules={[{ required: true, message: "Please enter a server name" }]}
       >
         <Input placeholder="e.g., my-custom-server" />
       </Form.Item>
@@ -491,7 +552,7 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
       <Form.Item
         name="package"
         label="Package"
-        rules={[{ required: true, message: 'Please enter a package' }]}
+        rules={[{ required: true, message: "Please enter a package" }]}
         help="Format: runtime::package@version (e.g., npx::my-server@1.0.0)"
       >
         <Input placeholder="e.g., uvx::my-custom-server@1.0.0" />
@@ -506,7 +567,10 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
           rows={2}
           placeholder="e.g., read_file, write_file, list_directory"
           onChange={(e) => {
-            const tools = e.target.value.split(',').map(t => t.trim()).filter(Boolean);
+            const tools = e.target.value
+              .split(",")
+              .map((t) => t.trim())
+              .filter(Boolean);
             setSelectedTools(tools);
           }}
         />
@@ -551,7 +615,10 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
         </Button>,
       ]}
     >
-      <Tabs activeKey={mode} onChange={(key) => setMode(key as 'browse' | 'custom')}>
+      <Tabs
+        activeKey={mode}
+        onChange={(key) => setMode(key as "browse" | "custom")}
+      >
         <TabPane tab="Browse Servers" key="browse">
           {renderBrowseMode()}
         </TabPane>
@@ -572,7 +639,7 @@ const AddServerModal: React.FC<AddServerModalProps> = ({ visible, onClose, onSuc
               readOnly: true,
               minimap: { enabled: false },
               fontSize: 12,
-              lineNumbers: 'off',
+              lineNumbers: "off",
             }}
           />
         </div>

--- a/src/renderer/components/ConfigEditor.tsx
+++ b/src/renderer/components/ConfigEditor.tsx
@@ -1,13 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Card, Button, Space, message, Alert, Input } from 'antd';
-import { SaveOutlined, DownloadOutlined, ReloadOutlined } from '@ant-design/icons';
-import MonacoEditor from '@monaco-editor/react';
+import React, { useState, useEffect } from "react";
+import { Card, Button, Space, message, Alert, Input } from "antd";
+import {
+  SaveOutlined,
+  DownloadOutlined,
+  ReloadOutlined,
+} from "@ant-design/icons";
+import MonacoEditor from "@monaco-editor/react";
 
 const { TextArea } = Input;
 
 const ConfigEditor: React.FC = () => {
-  const [configContent, setConfigContent] = useState<string>('');
-  const [originalContent, setOriginalContent] = useState<string>('');
+  const [configContent, setConfigContent] = useState<string>("");
+  const [originalContent, setOriginalContent] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const [useTextArea, setUseTextArea] = useState(false);
 
@@ -19,14 +23,14 @@ const ConfigEditor: React.FC = () => {
     setLoading(true);
     try {
       const config = await window.electronAPI.loadConfig();
-      console.log('Loaded config:', config);
-      const content = config.content || 'servers = []';
-      console.log('Config content:', content);
+      console.log("Loaded config:", config);
+      const content = config.content || "servers = []";
+      console.log("Config content:", content);
       setConfigContent(content);
       setOriginalContent(content);
     } catch (error) {
-      console.error('Failed to load config:', error);
-      message.error('Failed to load configuration');
+      console.error("Failed to load config:", error);
+      message.error("Failed to load configuration");
     } finally {
       setLoading(false);
     }
@@ -36,27 +40,27 @@ const ConfigEditor: React.FC = () => {
     try {
       await window.electronAPI.saveConfig(configContent);
       setOriginalContent(configContent);
-      message.success('Configuration saved successfully');
+      message.success("Configuration saved successfully");
     } catch (error) {
-      console.error('Failed to save config:', error);
-      message.error('Failed to save configuration');
+      console.error("Failed to save config:", error);
+      message.error("Failed to save configuration");
     }
   };
 
   const exportConfig = async () => {
     try {
       const exportedConfig = await window.electronAPI.exportConfig();
-      const blob = new Blob([exportedConfig], { type: 'application/json' });
+      const blob = new Blob([exportedConfig], { type: "application/json" });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
-      a.download = 'mcpd-config-export.json';
+      a.download = "mcpd-config-export.json";
       a.click();
       URL.revokeObjectURL(url);
-      message.success('Configuration exported successfully');
+      message.success("Configuration exported successfully");
     } catch (error) {
-      console.error('Failed to export config:', error);
-      message.error('Failed to export configuration');
+      console.error("Failed to export config:", error);
+      message.error("Failed to export configuration");
     }
   };
 
@@ -83,10 +87,7 @@ const ConfigEditor: React.FC = () => {
             >
               Reload
             </Button>
-            <Button
-              icon={<DownloadOutlined />}
-              onClick={exportConfig}
-            >
+            <Button icon={<DownloadOutlined />} onClick={exportConfig}>
               Export
             </Button>
             <Button
@@ -95,13 +96,15 @@ const ConfigEditor: React.FC = () => {
               onClick={saveConfig}
               disabled={!hasChanges}
             >
-              Save {hasChanges && '*'}
+              Save {hasChanges && "*"}
             </Button>
           </Space>
         }
       >
         {loading ? (
-          <div style={{ padding: 20, textAlign: 'center' }}>Loading configuration...</div>
+          <div style={{ padding: 20, textAlign: "center" }}>
+            Loading configuration...
+          </div>
         ) : useTextArea ? (
           <>
             <TextArea
@@ -109,13 +112,17 @@ const ConfigEditor: React.FC = () => {
               onChange={(e) => setConfigContent(e.target.value)}
               style={{
                 minHeight: 600,
-                fontFamily: 'monospace',
+                fontFamily: "monospace",
                 fontSize: 14,
-                backgroundColor: '#1e1e1e',
-                color: '#d4d4d4',
+                backgroundColor: "#1e1e1e",
+                color: "#d4d4d4",
               }}
             />
-            <Button size="small" onClick={() => setUseTextArea(false)} style={{ marginTop: 10 }}>
+            <Button
+              size="small"
+              onClick={() => setUseTextArea(false)}
+              style={{ marginTop: 10 }}
+            >
               Try Monaco Editor
             </Button>
           </>
@@ -126,21 +133,35 @@ const ConfigEditor: React.FC = () => {
               language="toml"
               theme="vs-dark"
               value={configContent}
-              onChange={(value) => setConfigContent(value || '')}
+              onChange={(value) => setConfigContent(value || "")}
               loading={loading}
               options={{
                 minimap: { enabled: false },
                 fontSize: 14,
-                wordWrap: 'on',
+                wordWrap: "on",
                 formatOnPaste: true,
                 formatOnType: true,
               }}
             />
             {/* Debug info - remove this after fixing */}
-            <div style={{ marginTop: 10, padding: 10, background: '#2a2a2a', borderRadius: 4, fontSize: 12, color: '#888' }}>
-              <strong>Debug Info:</strong> Config loaded with {configContent.length} characters
-              {configContent.length === 0 && ' (Content is empty!)'}
-              <Button size="small" onClick={() => setUseTextArea(true)} style={{ marginLeft: 10 }}>
+            <div
+              style={{
+                marginTop: 10,
+                padding: 10,
+                background: "#2a2a2a",
+                borderRadius: 4,
+                fontSize: 12,
+                color: "#888",
+              }}
+            >
+              <strong>Debug Info:</strong> Config loaded with{" "}
+              {configContent.length} characters
+              {configContent.length === 0 && " (Content is empty!)"}
+              <Button
+                size="small"
+                onClick={() => setUseTextArea(true)}
+                style={{ marginLeft: 10 }}
+              >
                 Use Simple Editor
               </Button>
             </div>

--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -1,7 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import { Card, Row, Col, Statistic, Alert, Spin, Button } from 'antd';
-import { CheckCircleOutlined, CloseCircleOutlined, CloudServerOutlined, ToolOutlined, ApiOutlined } from '@ant-design/icons';
-import { DaemonStatus, MCPServer } from '@shared/types';
+import React, { useEffect, useState } from "react";
+import { Card, Row, Col, Statistic, Alert, Spin, Button } from "antd";
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  CloudServerOutlined,
+  ToolOutlined,
+  ApiOutlined,
+} from "@ant-design/icons";
+import { DaemonStatus, MCPServer } from "@shared/types";
 
 interface DashboardProps {
   daemonStatus: DaemonStatus;
@@ -22,7 +28,7 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
     setLoading(true);
     try {
       const serverList = await window.electronAPI.listServers();
-      
+
       // Fetch tools for each server and count them
       let toolCount = 0;
       const serversWithTools = await Promise.all(
@@ -41,13 +47,13 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
               tools: [],
             };
           }
-        })
+        }),
       );
-      
+
       setServers(serversWithTools);
       setTotalTools(toolCount);
     } catch (error) {
-      console.error('Failed to load servers:', error);
+      console.error("Failed to load servers:", error);
     } finally {
       setLoading(false);
     }
@@ -60,9 +66,17 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
           <Card>
             <Statistic
               title="Daemon Status"
-              value={daemonStatus.running ? 'Running' : 'Stopped'}
-              valueStyle={{ color: daemonStatus.running ? '#52c41a' : '#ff4d4f' }}
-              prefix={daemonStatus.running ? <CheckCircleOutlined /> : <CloseCircleOutlined />}
+              value={daemonStatus.running ? "Running" : "Stopped"}
+              valueStyle={{
+                color: daemonStatus.running ? "#52c41a" : "#ff4d4f",
+              }}
+              prefix={
+                daemonStatus.running ? (
+                  <CheckCircleOutlined />
+                ) : (
+                  <CloseCircleOutlined />
+                )
+              }
             />
           </Card>
         </Col>
@@ -88,7 +102,7 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
           <Card>
             <Statistic
               title="API Endpoint"
-              value={daemonStatus.apiUrl || 'Not Available'}
+              value={daemonStatus.apiUrl || "Not Available"}
               valueStyle={{ fontSize: 14 }}
             />
           </Card>
@@ -97,12 +111,14 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
 
       <Row gutter={[16, 16]} style={{ marginTop: 24 }}>
         <Col span={24}>
-          <Card 
+          <Card
             title="System Status"
             extra={
               <Button
                 icon={<ApiOutlined />}
-                onClick={() => window.open(`http://localhost:8090/api/v1/servers`, '_blank')}
+                onClick={() =>
+                  window.open(`http://localhost:8090/api/v1/servers`, "_blank")
+                }
                 disabled={!daemonStatus.running}
               >
                 API Docs
@@ -117,7 +133,7 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
                 showIcon
               />
             ) : loading ? (
-              <div style={{ textAlign: 'center', padding: 40 }}>
+              <div style={{ textAlign: "center", padding: 40 }}>
                 <Spin size="large" />
               </div>
             ) : (

--- a/src/renderer/components/ExportConfigModal.tsx
+++ b/src/renderer/components/ExportConfigModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Modal,
   Tabs,
@@ -11,8 +11,7 @@ import {
   Divider,
   Radio,
   Input,
-  Checkbox,
-} from 'antd';
+} from "antd";
 import {
   CopyOutlined,
   DownloadOutlined,
@@ -20,23 +19,28 @@ import {
   DesktopOutlined,
   ApiOutlined,
   CloudServerOutlined,
-} from '@ant-design/icons';
-import MonacoEditor from '@monaco-editor/react';
+} from "@ant-design/icons";
+import MonacoEditor from "@monaco-editor/react";
 
 const { TabPane } = Tabs;
-const { Title, Text, Paragraph } = Typography;
+const { Text } = Typography;
 
 interface ExportConfigModalProps {
   visible: boolean;
   onClose: () => void;
 }
 
-const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose }) => {
-  const [activeTab, setActiveTab] = useState('claude-desktop');
-  const [configContent, setConfigContent] = useState('');
-  const [bridgeMode, setBridgeMode] = useState<'unified' | 'individual' | 'direct'>('unified');
-  const [mcpdUrl, setMcpdUrl] = useState('http://localhost:8090');
-  const [includeNamespacing, setIncludeNamespacing] = useState(true);
+const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
+  visible,
+  onClose,
+}) => {
+  const [activeTab, setActiveTab] = useState("claude-desktop");
+  const [configContent, setConfigContent] = useState("");
+  const [bridgeMode, setBridgeMode] = useState<
+    "unified" | "individual" | "direct"
+  >("unified");
+  const [mcpdUrl, setMcpdUrl] = useState("http://localhost:8090");
+  const [includeNamespacing] = useState(true);
 
   useEffect(() => {
     if (visible) {
@@ -45,14 +49,14 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
   }, [visible, activeTab, bridgeMode, mcpdUrl, includeNamespacing]);
 
   const generateConfig = async () => {
-    if (activeTab === 'claude-desktop') {
-      if (bridgeMode === 'unified') {
+    if (activeTab === "claude-desktop") {
+      if (bridgeMode === "unified") {
         // Unified mcpd-proxy config (all servers via single proxy).
         const config = {
           mcpServers: {
-            'mcpd': {
-              command: 'npx',
-              args: ['@mozilla-ai/mcpd-proxy'],
+            mcpd: {
+              command: "npx",
+              args: ["@mozilla-ai/mcpd-proxy"],
               env: {
                 MCPD_ADDR: mcpdUrl,
               },
@@ -60,7 +64,7 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
           },
         };
         setConfigContent(JSON.stringify(config, null, 2));
-      } else if (bridgeMode === 'individual') {
+      } else if (bridgeMode === "individual") {
         // Individual mcpd-proxy configs (one per server).
         try {
           const servers = await window.electronAPI.listServers();
@@ -68,8 +72,8 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
 
           for (const server of servers) {
             config.mcpServers[`mcpd-${server.name}`] = {
-              command: 'npx',
-              args: ['@mozilla-ai/mcpd-proxy'],
+              command: "npx",
+              args: ["@mozilla-ai/mcpd-proxy"],
               env: {
                 MCPD_ADDR: mcpdUrl,
               },
@@ -78,8 +82,8 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
 
           setConfigContent(JSON.stringify(config, null, 2));
         } catch (error) {
-          console.error('Failed to generate config:', error);
-          message.error('Failed to generate configuration');
+          console.error("Failed to generate config:", error);
+          message.error("Failed to generate configuration");
         }
       } else {
         // Direct server configs (no proxy).
@@ -89,10 +93,13 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
 
           for (const server of servers) {
             // Parse the package string to determine runtime.
-            const [runtime, pkg] = server.package?.split('::') || ['npx', server.package];
+            const [runtime, pkg] = server.package?.split("::") || [
+              "npx",
+              server.package,
+            ];
 
             config.mcpServers[server.name] = {
-              command: runtime || 'npx',
+              command: runtime || "npx",
               args: [pkg || server.package],
             };
 
@@ -110,11 +117,11 @@ const ExportConfigModal: React.FC<ExportConfigModalProps> = ({ visible, onClose 
 
           setConfigContent(JSON.stringify(config, null, 2));
         } catch (error) {
-          console.error('Failed to generate config:', error);
-          message.error('Failed to generate configuration');
+          console.error("Failed to generate config:", error);
+          message.error("Failed to generate configuration");
         }
       }
-    } else if (activeTab === 'api') {
+    } else if (activeTab === "api") {
       // Generate API usage examples using mcpd's built-in HTTP API.
       const apiExamples = `# mcpd Access Methods
 
@@ -182,19 +189,19 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(configContent);
-    message.success('Configuration copied to clipboard');
+    message.success("Configuration copied to clipboard");
   };
 
   const downloadConfig = () => {
-    const blob = new Blob([configContent], { type: 'text/plain' });
+    const blob = new Blob([configContent], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
 
-    let filename = 'config';
-    if (activeTab === 'claude-desktop') {
-      filename = 'claude_desktop_config.json';
-    } else if (activeTab === 'api') {
-      filename = 'api-examples.md';
+    let filename = "config";
+    if (activeTab === "claude-desktop") {
+      filename = "claude_desktop_config.json";
+    } else if (activeTab === "api") {
+      filename = "api-examples.md";
     }
 
     a.href = url;
@@ -214,11 +221,7 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
         <Button key="close" onClick={onClose}>
           Close
         </Button>,
-        <Button
-          key="copy"
-          icon={<CopyOutlined />}
-          onClick={copyToClipboard}
-        >
+        <Button key="copy" icon={<CopyOutlined />} onClick={copyToClipboard}>
           Copy to Clipboard
         </Button>,
         <Button
@@ -241,7 +244,7 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
           }
           key="claude-desktop"
         >
-          <Space direction="vertical" style={{ width: '100%' }} size="large">
+          <Space direction="vertical" style={{ width: "100%" }} size="large">
             <Alert
               message="Claude Desktop Configuration"
               description="Copy this configuration to your Claude Desktop config file located at:"
@@ -249,7 +252,10 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
               showIcon
               action={
                 <Space direction="vertical" align="end">
-                  <Text code>~/Library/Application Support/Claude/claude_desktop_config.json</Text>
+                  <Text code>
+                    ~/Library/Application
+                    Support/Claude/claude_desktop_config.json
+                  </Text>
                   <Text type="secondary">(macOS)</Text>
                   <Text code>%APPDATA%\Claude\claude_desktop_config.json</Text>
                   <Text type="secondary">(Windows)</Text>
@@ -261,7 +267,12 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
               <Radio.Group
                 value={bridgeMode}
                 onChange={(e) => setBridgeMode(e.target.value)}
-                style={{ marginBottom: 16, display: 'flex', flexDirection: 'column', gap: 8 }}
+                style={{
+                  marginBottom: 16,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 8,
+                }}
               >
                 <Radio value="unified">
                   <Space direction="vertical" style={{ marginLeft: 24 }}>
@@ -271,7 +282,8 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
                       <Text type="secondary">(Recommended)</Text>
                     </Space>
                     <Text type="secondary" style={{ fontSize: 12 }}>
-                      Single mcpd-proxy connection exposing all servers with namespaced tools
+                      Single mcpd-proxy connection exposing all servers with
+                      namespaced tools
                     </Text>
                   </Space>
                 </Radio>
@@ -282,7 +294,8 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
                       <strong>Individual Proxies</strong>
                     </Space>
                     <Text type="secondary" style={{ fontSize: 12 }}>
-                      Separate mcpd-proxy connection for each server (better isolation)
+                      Separate mcpd-proxy connection for each server (better
+                      isolation)
                     </Text>
                   </Space>
                 </Radio>
@@ -293,15 +306,16 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
                       <strong>Direct Connections</strong>
                     </Space>
                     <Text type="secondary" style={{ fontSize: 12 }}>
-                      Connect directly to each MCP server without mcpd (requires manual config updates)
+                      Connect directly to each MCP server without mcpd (requires
+                      manual config updates)
                     </Text>
                   </Space>
                 </Radio>
               </Radio.Group>
 
-              {(bridgeMode === 'unified' || bridgeMode === 'individual') && (
-                <Space direction="vertical" style={{ width: '100%' }}>
-                  <Divider style={{ margin: '12px 0' }} />
+              {(bridgeMode === "unified" || bridgeMode === "individual") && (
+                <Space direction="vertical" style={{ width: "100%" }}>
+                  <Divider style={{ margin: "12px 0" }} />
                   <Text>mcpd URL:</Text>
                   <Input
                     value={mcpdUrl}
@@ -310,9 +324,13 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
                   />
 
                   <Alert
-                    message={bridgeMode === 'unified' ? 'Unified Proxy Benefits' : 'Individual Proxy Benefits'}
+                    message={
+                      bridgeMode === "unified"
+                        ? "Unified Proxy Benefits"
+                        : "Individual Proxy Benefits"
+                    }
                     description={
-                      bridgeMode === 'unified' ? (
+                      bridgeMode === "unified" ? (
                         <ul style={{ marginBottom: 0, fontSize: 12 }}>
                           <li>Single configuration entry</li>
                           <li>All servers automatically available</li>
@@ -358,17 +376,14 @@ MCPD_ADDR=${mcpdUrl} npx @mozilla-ai/mcpd-proxy
 
       <MonacoEditor
         height="400px"
-        language={
-          activeTab === 'claude-desktop' ? 'json' :
-          'markdown'
-        }
+        language={activeTab === "claude-desktop" ? "json" : "markdown"}
         theme="vs-dark"
         value={configContent}
         options={{
           readOnly: true,
           minimap: { enabled: false },
           fontSize: 13,
-          wordWrap: 'on',
+          wordWrap: "on",
         }}
       />
     </Modal>

--- a/src/renderer/components/LogViewer.tsx
+++ b/src/renderer/components/LogViewer.tsx
@@ -1,17 +1,21 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Card, Button, Space, Select, Input, Badge } from 'antd';
-import { ReloadOutlined, ClearOutlined, DownloadOutlined } from '@ant-design/icons';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import 'xterm/css/xterm.css';
+import React, { useState, useEffect, useRef } from "react";
+import { Card, Button, Space, Select, Input, Badge } from "antd";
+import {
+  ReloadOutlined,
+  ClearOutlined,
+  DownloadOutlined,
+} from "@ant-design/icons";
+import { Terminal } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import "xterm/css/xterm.css";
 
 const { Search } = Input;
 
 const LogViewer: React.FC = () => {
   const [logs, setLogs] = useState<string[]>([]);
   const [filteredLogs, setFilteredLogs] = useState<string[]>([]);
-  const [logLevel, setLogLevel] = useState<string>('all');
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [logLevel, setLogLevel] = useState<string>("all");
+  const [searchTerm, setSearchTerm] = useState<string>("");
   const [autoRefresh, setAutoRefresh] = useState<boolean>(false);
   const terminalRef = useRef<HTMLDivElement>(null);
   const terminal = useRef<Terminal | null>(null);
@@ -21,15 +25,15 @@ const LogViewer: React.FC = () => {
     if (terminalRef.current && !terminal.current) {
       terminal.current = new Terminal({
         theme: {
-          background: '#1e1e1e',
-          foreground: '#cccccc',
+          background: "#1e1e1e",
+          foreground: "#cccccc",
         },
         fontSize: 12,
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
         cursorBlink: false,
         disableStdin: true,
       });
-      
+
       fitAddon.current = new FitAddon();
       terminal.current.loadAddon(fitAddon.current);
       terminal.current.open(terminalRef.current);
@@ -55,7 +59,7 @@ const LogViewer: React.FC = () => {
   useEffect(() => {
     if (terminal.current) {
       terminal.current.clear();
-      filteredLogs.forEach(log => {
+      filteredLogs.forEach((log) => {
         const coloredLog = colorizeLog(log);
         terminal.current!.writeln(coloredLog);
       });
@@ -67,7 +71,7 @@ const LogViewer: React.FC = () => {
       const logLines = await window.electronAPI.getDaemonLogs(500);
       setLogs(logLines);
     } catch (error) {
-      console.error('Failed to load logs:', error);
+      console.error("Failed to load logs:", error);
     }
   };
 
@@ -75,16 +79,16 @@ const LogViewer: React.FC = () => {
     let filtered = [...logs];
 
     // Filter by log level
-    if (logLevel !== 'all') {
-      filtered = filtered.filter(log => 
-        log.toLowerCase().includes(logLevel.toLowerCase())
+    if (logLevel !== "all") {
+      filtered = filtered.filter((log) =>
+        log.toLowerCase().includes(logLevel.toLowerCase()),
       );
     }
 
     // Filter by search term
     if (searchTerm) {
-      filtered = filtered.filter(log =>
-        log.toLowerCase().includes(searchTerm.toLowerCase())
+      filtered = filtered.filter((log) =>
+        log.toLowerCase().includes(searchTerm.toLowerCase()),
       );
     }
 
@@ -92,13 +96,13 @@ const LogViewer: React.FC = () => {
   };
 
   const colorizeLog = (log: string): string => {
-    if (log.includes('ERROR')) {
+    if (log.includes("ERROR")) {
       return `\x1b[31m${log}\x1b[0m`; // Red
-    } else if (log.includes('WARN')) {
+    } else if (log.includes("WARN")) {
       return `\x1b[33m${log}\x1b[0m`; // Yellow
-    } else if (log.includes('INFO')) {
+    } else if (log.includes("INFO")) {
       return `\x1b[36m${log}\x1b[0m`; // Cyan
-    } else if (log.includes('DEBUG')) {
+    } else if (log.includes("DEBUG")) {
       return `\x1b[90m${log}\x1b[0m`; // Gray
     }
     return log;
@@ -111,9 +115,9 @@ const LogViewer: React.FC = () => {
   };
 
   const downloadLogs = () => {
-    const blob = new Blob([logs.join('\n')], { type: 'text/plain' });
+    const blob = new Blob([logs.join("\n")], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
     a.download = `mcpd-logs-${new Date().toISOString()}.log`;
     a.click();
@@ -128,11 +132,11 @@ const LogViewer: React.FC = () => {
       debug: 0,
     };
 
-    logs.forEach(log => {
-      if (log.includes('ERROR')) stats.error++;
-      else if (log.includes('WARN')) stats.warn++;
-      else if (log.includes('INFO')) stats.info++;
-      else if (log.includes('DEBUG')) stats.debug++;
+    logs.forEach((log) => {
+      if (log.includes("ERROR")) stats.error++;
+      else if (log.includes("WARN")) stats.warn++;
+      else if (log.includes("INFO")) stats.info++;
+      else if (log.includes("DEBUG")) stats.debug++;
     });
 
     return stats;
@@ -145,8 +149,8 @@ const LogViewer: React.FC = () => {
       title={
         <Space>
           <span>Log Viewer</span>
-          <Badge count={stats.error} style={{ backgroundColor: '#ff4d4f' }} />
-          <Badge count={stats.warn} style={{ backgroundColor: '#faad14' }} />
+          <Badge count={stats.error} style={{ backgroundColor: "#ff4d4f" }} />
+          <Badge count={stats.warn} style={{ backgroundColor: "#faad14" }} />
         </Space>
       }
       extra={
@@ -163,18 +167,18 @@ const LogViewer: React.FC = () => {
             onChange={setLogLevel}
             style={{ width: 100 }}
             options={[
-              { label: 'All', value: 'all' },
-              { label: 'Error', value: 'error' },
-              { label: 'Warn', value: 'warn' },
-              { label: 'Info', value: 'info' },
-              { label: 'Debug', value: 'debug' },
+              { label: "All", value: "all" },
+              { label: "Error", value: "error" },
+              { label: "Warn", value: "warn" },
+              { label: "Info", value: "info" },
+              { label: "Debug", value: "debug" },
             ]}
           />
           <Button
-            type={autoRefresh ? 'primary' : 'default'}
+            type={autoRefresh ? "primary" : "default"}
             onClick={() => setAutoRefresh(!autoRefresh)}
           >
-            Auto Refresh: {autoRefresh ? 'ON' : 'OFF'}
+            Auto Refresh: {autoRefresh ? "ON" : "OFF"}
           </Button>
           <Button icon={<ClearOutlined />} onClick={clearTerminal}>
             Clear
@@ -192,7 +196,7 @@ const LogViewer: React.FC = () => {
         ref={terminalRef}
         style={{
           height: 600,
-          backgroundColor: '#1e1e1e',
+          backgroundColor: "#1e1e1e",
           padding: 8,
           borderRadius: 4,
         }}

--- a/src/renderer/components/QuickSetup.tsx
+++ b/src/renderer/components/QuickSetup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Card,
   Row,
@@ -12,7 +12,7 @@ import {
   Divider,
   Modal,
   Input,
-} from 'antd';
+} from "antd";
 import {
   RocketOutlined,
   CloudOutlined,
@@ -22,7 +22,7 @@ import {
   DesktopOutlined,
   GlobalOutlined,
   LoadingOutlined,
-} from '@ant-design/icons';
+} from "@ant-design/icons";
 
 const { Text, Title, Paragraph } = Typography;
 
@@ -34,8 +34,7 @@ interface ServerInfo {
 const QuickSetup: React.FC = () => {
   const [servers, setServers] = useState<ServerInfo[]>([]);
   const [loading, setLoading] = useState(false);
-  const [setupLoading, setSetupLoading] = useState<string>('');
-  const [httpUrl, setHttpUrl] = useState<string>('');
+  const [setupLoading, setSetupLoading] = useState<string>("");
 
   useEffect(() => {
     loadServers();
@@ -45,7 +44,7 @@ const QuickSetup: React.FC = () => {
     setLoading(true);
     try {
       const serverList = await window.electronAPI.listServers();
-      
+
       // Fetch tools for each server
       const serversWithTools = await Promise.all(
         serverList.map(async (server: any) => {
@@ -62,13 +61,13 @@ const QuickSetup: React.FC = () => {
               tools: [],
             };
           }
-        })
+        }),
       );
-      
+
       setServers(serversWithTools);
     } catch (error) {
-      console.error('Failed to load servers:', error);
-      message.error('Failed to load servers. Make sure the daemon is running.');
+      console.error("Failed to load servers:", error);
+      message.error("Failed to load servers. Make sure the daemon is running.");
     } finally {
       setLoading(false);
     }
@@ -81,13 +80,13 @@ const QuickSetup: React.FC = () => {
       if (result.success) {
         message.success(result.message);
       } else {
-        message.error('Failed to setup Claude Desktop');
+        message.error("Failed to setup Claude Desktop");
       }
     } catch (error) {
-      console.error('Failed to setup Claude:', error);
-      message.error('Failed to setup Claude Desktop');
+      console.error("Failed to setup Claude:", error);
+      message.error("Failed to setup Claude Desktop");
     } finally {
-      setSetupLoading('');
+      setSetupLoading("");
     }
   };
 
@@ -96,9 +95,8 @@ const QuickSetup: React.FC = () => {
     try {
       const result = await window.electronAPI.setupHTTP(serverName);
       if (result.success) {
-        setHttpUrl(result.url || '');
         Modal.success({
-          title: 'mcpd HTTP API',
+          title: "mcpd HTTP API",
           content: (
             <div>
               <Paragraph>{result.message}</Paragraph>
@@ -122,10 +120,10 @@ const QuickSetup: React.FC = () => {
         });
       }
     } catch (error) {
-      console.error('Failed to get HTTP info:', error);
-      message.error('Failed to get HTTP API info');
+      console.error("Failed to get HTTP info:", error);
+      message.error("Failed to get HTTP API info");
     } finally {
-      setSetupLoading('');
+      setSetupLoading("");
     }
   };
 
@@ -135,22 +133,25 @@ const QuickSetup: React.FC = () => {
       const result = await window.electronAPI.setupCursor(serverName);
       message.info(result.message);
     } catch (error) {
-      console.error('Failed to setup Cursor:', error);
-      message.error('Failed to setup Cursor');
+      console.error("Failed to setup Cursor:", error);
+      message.error("Failed to setup Cursor");
     } finally {
-      setSetupLoading('');
+      setSetupLoading("");
     }
   };
 
   const getServerIcon = (name: string) => {
-    if (name.includes('filesystem')) return <CloudOutlined />;
+    if (name.includes("filesystem")) return <CloudOutlined />;
     return <CodeOutlined />;
   };
 
   return (
-    <div style={{ padding: '24px' }}>
+    <div style={{ padding: "24px" }}>
       <div style={{ marginBottom: 32 }}>
-        <Title level={2} style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Title
+          level={2}
+          style={{ margin: 0, display: "flex", alignItems: "center", gap: 8 }}
+        >
           <RocketOutlined />
           Connect
         </Title>
@@ -175,7 +176,7 @@ const QuickSetup: React.FC = () => {
 
       {loading ? (
         <Card>
-          <div style={{ textAlign: 'center', padding: '40px' }}>
+          <div style={{ textAlign: "center", padding: "40px" }}>
             <LoadingOutlined style={{ fontSize: 24 }} />
             <div style={{ marginTop: 16 }}>Loading servers...</div>
           </div>
@@ -201,7 +202,7 @@ const QuickSetup: React.FC = () => {
                       </div>
                     </Space>
                   </Col>
-                  
+
                   <Col span={18}>
                     <Space size="middle" wrap>
                       <Button
@@ -212,7 +213,7 @@ const QuickSetup: React.FC = () => {
                       >
                         Connect to Claude Desktop
                       </Button>
-                      
+
                       <Button
                         icon={<ApiOutlined />}
                         onClick={() => setupCursor(server.name)}
@@ -231,12 +232,14 @@ const QuickSetup: React.FC = () => {
                     </Space>
                   </Col>
                 </Row>
-                
+
                 {server.tools.length > 0 && (
                   <>
-                    <Divider style={{ margin: '16px 0 8px' }} />
+                    <Divider style={{ margin: "16px 0 8px" }} />
                     <div>
-                      <Text type="secondary" style={{ fontSize: 12 }}>Available tools: </Text>
+                      <Text type="secondary" style={{ fontSize: 12 }}>
+                        Available tools:{" "}
+                      </Text>
                       <Space wrap style={{ marginTop: 4 }}>
                         {server.tools.slice(0, 8).map((tool) => (
                           <Tag key={tool} style={{ fontSize: 11 }}>
@@ -264,7 +267,7 @@ const QuickSetup: React.FC = () => {
           <Row gutter={[16, 16]}>
             <Col span={8}>
               <Space>
-                <CheckCircleOutlined style={{ color: '#52c41a' }} />
+                <CheckCircleOutlined style={{ color: "#52c41a" }} />
                 <div>
                   <Text strong>Claude Desktop</Text>
                   <div>
@@ -277,7 +280,7 @@ const QuickSetup: React.FC = () => {
             </Col>
             <Col span={8}>
               <Space>
-                <CheckCircleOutlined style={{ color: '#52c41a' }} />
+                <CheckCircleOutlined style={{ color: "#52c41a" }} />
                 <div>
                   <Text strong>Cursor</Text>
                   <div>
@@ -290,7 +293,7 @@ const QuickSetup: React.FC = () => {
             </Col>
             <Col span={8}>
               <Space>
-                <CheckCircleOutlined style={{ color: '#52c41a' }} />
+                <CheckCircleOutlined style={{ color: "#52c41a" }} />
                 <div>
                   <Text strong>HTTP API</Text>
                   <div>

--- a/src/renderer/components/ServerManager.tsx
+++ b/src/renderer/components/ServerManager.tsx
@@ -1,8 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Card, Table, Button, Tag, Space, message, Popconfirm } from 'antd';
-import { PlusOutlined, DeleteOutlined, ReloadOutlined } from '@ant-design/icons';
-import { MCPServer } from '@shared/types';
-import AddServerModal from './AddServerModal';
+import React, { useState, useEffect } from "react";
+import { Card, Table, Button, Tag, Space, message, Popconfirm } from "antd";
+import {
+  PlusOutlined,
+  DeleteOutlined,
+  ReloadOutlined,
+} from "@ant-design/icons";
+import { MCPServer } from "@shared/types";
+import AddServerModal from "./AddServerModal";
 
 const ServerManager: React.FC = () => {
   const [servers, setServers] = useState<MCPServer[]>([]);
@@ -17,7 +21,7 @@ const ServerManager: React.FC = () => {
     setLoading(true);
     try {
       const serverList = await window.electronAPI.listServers();
-      
+
       // Fetch tools for each server
       const serversWithTools = await Promise.all(
         serverList.map(async (server: any) => {
@@ -34,18 +38,17 @@ const ServerManager: React.FC = () => {
               tools: [],
             };
           }
-        })
+        }),
       );
-      
+
       setServers(serversWithTools);
     } catch (error) {
-      console.error('Failed to load servers:', error);
-      message.error('Failed to load servers');
+      console.error("Failed to load servers:", error);
+      message.error("Failed to load servers");
     } finally {
       setLoading(false);
     }
   };
-
 
   const handleRemoveServer = async (name: string) => {
     try {
@@ -53,51 +56,61 @@ const ServerManager: React.FC = () => {
       message.success(`Server ${name} removed successfully`);
       loadServers();
     } catch (error) {
-      console.error('Failed to remove server:', error);
-      message.error('Failed to remove server');
+      console.error("Failed to remove server:", error);
+      message.error("Failed to remove server");
     }
   };
 
   const columns = [
     {
-      title: 'Name',
-      dataIndex: 'name',
-      key: 'name',
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
       render: (text: string) => <strong>{text}</strong>,
     },
     {
-      title: 'Package',
-      dataIndex: 'package',
-      key: 'package',
-      render: (text: string) => text || 'N/A',
+      title: "Package",
+      dataIndex: "package",
+      key: "package",
+      render: (text: string) => text || "N/A",
     },
     {
-      title: 'Status',
-      dataIndex: 'status',
-      key: 'status',
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
       render: (status: string) => {
-        const color = status === 'running' ? 'green' : status === 'stopped' ? 'red' : 'orange';
+        const color =
+          status === "running"
+            ? "green"
+            : status === "stopped"
+              ? "red"
+              : "orange";
         return <Tag color={color}>{status.toUpperCase()}</Tag>;
       },
     },
     {
-      title: 'Health',
-      dataIndex: 'health',
-      key: 'health',
+      title: "Health",
+      dataIndex: "health",
+      key: "health",
       render: (health: string) => {
-        const color = health === 'healthy' ? 'green' : health === 'unhealthy' ? 'red' : 'default';
-        return <Tag color={color}>{health?.toUpperCase() || 'UNKNOWN'}</Tag>;
+        const color =
+          health === "healthy"
+            ? "green"
+            : health === "unhealthy"
+              ? "red"
+              : "default";
+        return <Tag color={color}>{health?.toUpperCase() || "UNKNOWN"}</Tag>;
       },
     },
     {
-      title: 'Tools',
-      dataIndex: 'tools',
-      key: 'tools',
+      title: "Tools",
+      dataIndex: "tools",
+      key: "tools",
       render: (tools: string[]) => tools?.length || 0,
     },
     {
-      title: 'Actions',
-      key: 'actions',
+      title: "Actions",
+      key: "actions",
       render: (_: any, record: MCPServer) => (
         <Space>
           <Popconfirm
@@ -116,35 +129,39 @@ const ServerManager: React.FC = () => {
   return (
     <>
       <Card
-      title="MCP Servers"
-      extra={
-        <Space>
-          <Button icon={<ReloadOutlined />} onClick={loadServers}>
-            Refresh
-          </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setAddModalVisible(true)}>
-            Add Server
-          </Button>
-        </Space>
-      }
-    >
-      <Table
-        columns={columns}
-        dataSource={servers}
-        rowKey="name"
-        loading={loading}
-        pagination={false}
-      />
-    </Card>
+        title="MCP Servers"
+        extra={
+          <Space>
+            <Button icon={<ReloadOutlined />} onClick={loadServers}>
+              Refresh
+            </Button>
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={() => setAddModalVisible(true)}
+            >
+              Add Server
+            </Button>
+          </Space>
+        }
+      >
+        <Table
+          columns={columns}
+          dataSource={servers}
+          rowKey="name"
+          loading={loading}
+          pagination={false}
+        />
+      </Card>
 
-    <AddServerModal
-      visible={addModalVisible}
-      onClose={() => setAddModalVisible(false)}
-      onSuccess={() => {
-        setAddModalVisible(false);
-        loadServers();
-      }}
-    />
+      <AddServerModal
+        visible={addModalVisible}
+        onClose={() => setAddModalVisible(false)}
+        onSuccess={() => {
+          setAddModalVisible(false);
+          loadServers();
+        }}
+      />
     </>
   );
 };

--- a/src/renderer/components/SimpleExportModal.tsx
+++ b/src/renderer/components/SimpleExportModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Modal,
   Tabs,
@@ -9,19 +9,18 @@ import {
   Card,
   Tag,
   Input,
-  List,
   Alert,
-} from 'antd';
+} from "antd";
 import {
   CopyOutlined,
   RocketOutlined,
   GithubOutlined,
   CloudOutlined,
   CodeOutlined,
-} from '@ant-design/icons';
+} from "@ant-design/icons";
 
 const { TabPane } = Tabs;
-const { Text, Title } = Typography;
+const { Text } = Typography;
 
 interface SimpleExportModalProps {
   visible: boolean;
@@ -33,10 +32,12 @@ interface ServerInfo {
   tools: string[];
 }
 
-const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose }) => {
+const SimpleExportModal: React.FC<SimpleExportModalProps> = ({
+  visible,
+  onClose,
+}) => {
   const [servers, setServers] = useState<ServerInfo[]>([]);
-  const [selectedServer, setSelectedServer] = useState<string>('');
-  const [loading, setLoading] = useState(false);
+  const [selectedServer, setSelectedServer] = useState<string>("");
 
   useEffect(() => {
     if (visible) {
@@ -45,7 +46,6 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
   }, [visible]);
 
   const loadServers = async () => {
-    setLoading(true);
     try {
       const serverList = await window.electronAPI.listServers();
       setServers(serverList);
@@ -53,20 +53,18 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
         setSelectedServer(serverList[0].name);
       }
     } catch (error) {
-      console.error('Failed to load servers:', error);
-    } finally {
-      setLoading(false);
+      console.error("Failed to load servers:", error);
     }
   };
 
   const copyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
-    message.success('Command copied to clipboard!');
+    message.success("Command copied to clipboard!");
   };
 
   const getServerIcon = (name: string) => {
-    if (name.includes('github')) return <GithubOutlined />;
-    if (name.includes('filesystem')) return <CloudOutlined />;
+    if (name.includes("github")) return <GithubOutlined />;
+    if (name.includes("filesystem")) return <CloudOutlined />;
     return <CodeOutlined />;
   };
 
@@ -87,17 +85,17 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
         </Button>,
       ]}
     >
-      <Space direction="vertical" style={{ width: '100%' }} size="large">
+      <Space direction="vertical" style={{ width: "100%" }} size="large">
         {/* Server Selection */}
         <div>
-          <Text strong style={{ marginBottom: 8, display: 'block' }}>
+          <Text strong style={{ marginBottom: 8, display: "block" }}>
             Select MCP Server to Install:
           </Text>
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             {servers.map((server) => (
               <Button
                 key={server.name}
-                type={selectedServer === server.name ? 'primary' : 'default'}
+                type={selectedServer === server.name ? "primary" : "default"}
                 icon={getServerIcon(server.name)}
                 onClick={() => setSelectedServer(server.name)}
               >
@@ -121,26 +119,36 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                 key="cursor"
               >
                 <Card>
-                  <Space direction="vertical" style={{ width: '100%' }}>
+                  <Space direction="vertical" style={{ width: "100%" }}>
                     <Text type="secondary">
-                      Paste and run this command in your terminal to set up Cursor with MCP
+                      Paste and run this command in your terminal to set up
+                      Cursor with MCP
                     </Text>
-                    <div style={{ position: 'relative' }}>
+                    <div style={{ position: "relative" }}>
                       <Input.TextArea
                         value={`mcpd-setup ${selectedServer} --client cursor`}
                         readOnly
                         autoSize
-                        style={{ fontFamily: 'monospace', fontSize: 14, paddingRight: 40 }}
+                        style={{
+                          fontFamily: "monospace",
+                          fontSize: 14,
+                          paddingRight: 40,
+                        }}
                       />
                       <Button
                         icon={<CopyOutlined />}
                         size="small"
-                        style={{ position: 'absolute', right: 4, top: 4 }}
-                        onClick={() => copyCommand(`mcpd-setup ${selectedServer} --client cursor`)}
+                        style={{ position: "absolute", right: 4, top: 4 }}
+                        onClick={() =>
+                          copyCommand(
+                            `mcpd-setup ${selectedServer} --client cursor`,
+                          )
+                        }
                       />
                     </div>
                     <Text type="secondary" style={{ fontSize: 12 }}>
-                      After running the command, restart Cursor to start using the MCP Server.
+                      After running the command, restart Cursor to start using
+                      the MCP Server.
                     </Text>
                   </Space>
                 </Card>
@@ -156,7 +164,7 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                 key="claude"
               >
                 <Card>
-                  <Space direction="vertical" style={{ width: '100%' }}>
+                  <Space direction="vertical" style={{ width: "100%" }}>
                     <Text type="secondary">
                       For Claude Desktop, configure mcpd-proxy:
                     </Text>
@@ -164,7 +172,7 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                       value={`mcpd-setup ${selectedServer} --client claude`}
                       readOnly
                       autoSize
-                      style={{ fontFamily: 'monospace', fontSize: 14 }}
+                      style={{ fontFamily: "monospace", fontSize: 14 }}
                     />
                     <Alert
                       message="Note"
@@ -186,7 +194,7 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                 key="windsurf"
               >
                 <Card>
-                  <Space direction="vertical" style={{ width: '100%' }}>
+                  <Space direction="vertical" style={{ width: "100%" }}>
                     <Text type="secondary">
                       Set up Windsurf with this command:
                     </Text>
@@ -194,7 +202,7 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                       value={`mcpd-setup ${selectedServer} --client windsurf`}
                       readOnly
                       autoSize
-                      style={{ fontFamily: 'monospace', fontSize: 14 }}
+                      style={{ fontFamily: "monospace", fontSize: 14 }}
                     />
                     <Text type="secondary" style={{ fontSize: 12 }}>
                       Check Windsurf documentation for MCP support status.
@@ -213,31 +221,41 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                 key="http"
               >
                 <Card>
-                  <Space direction="vertical" style={{ width: '100%' }}>
+                  <Space direction="vertical" style={{ width: "100%" }}>
                     <Text type="secondary">
                       Use the mcpd HTTP API directly:
                     </Text>
-                    <div style={{
-                      background: 'rgba(0,0,0,0.05)',
-                      padding: 8,
-                      borderRadius: 4,
-                      marginTop: 8
-                    }}>
+                    <div
+                      style={{
+                        background: "rgba(0,0,0,0.05)",
+                        padding: 8,
+                        borderRadius: 4,
+                        marginTop: 8,
+                      }}
+                    >
                       <code style={{ fontSize: 12 }}>
-                        http://localhost:8090/api/v1/servers/{selectedServer}/tools
+                        http://localhost:8090/api/v1/servers/{selectedServer}
+                        /tools
                       </code>
                     </div>
-                    <Text type="secondary" style={{ fontSize: 12, marginTop: 8 }}>
+                    <Text
+                      type="secondary"
+                      style={{ fontSize: 12, marginTop: 8 }}
+                    >
                       Or use the JavaScript SDK:
                     </Text>
                     <Input.TextArea
                       value={`npm install @mozilla-ai/mcpd`}
                       readOnly
                       autoSize
-                      style={{ fontFamily: 'monospace', fontSize: 14 }}
+                      style={{ fontFamily: "monospace", fontSize: 14 }}
                     />
-                    <Text type="secondary" style={{ fontSize: 12, marginTop: 8 }}>
-                      For STDIO-based IDE connections, use mcpd-proxy: npx @mozilla-ai/mcpd-proxy
+                    <Text
+                      type="secondary"
+                      style={{ fontSize: 12, marginTop: 8 }}
+                    >
+                      For STDIO-based IDE connections, use mcpd-proxy: npx
+                      @mozilla-ai/mcpd-proxy
                     </Text>
                   </Space>
                 </Card>
@@ -250,7 +268,7 @@ const SimpleExportModal: React.FC<SimpleExportModalProps> = ({ visible, onClose 
                 {(() => {
                   const server = servers.find((s) => s.name === selectedServer);
                   if (!server || !server.tools) return null;
-                  
+
                   return (
                     <>
                       {server.tools.slice(0, 6).map((tool) => (

--- a/src/renderer/components/ToolExplorer.tsx
+++ b/src/renderer/components/ToolExplorer.tsx
@@ -1,18 +1,27 @@
-import React, { useState, useEffect } from 'react';
-import { Card, Select, List, Button, Form, Input, Typography, Space, message, Spin, Empty } from 'antd';
-import { PlayCircleOutlined, CopyOutlined } from '@ant-design/icons';
-import { MCPServer, MCPTool } from '@shared/types';
-import MonacoEditor from '@monaco-editor/react';
+import React, { useState, useEffect } from "react";
+import {
+  Card,
+  Select,
+  List,
+  Button,
+  Typography,
+  Space,
+  message,
+  Spin,
+  Empty,
+} from "antd";
+import { PlayCircleOutlined, CopyOutlined } from "@ant-design/icons";
+import { MCPServer, MCPTool } from "@shared/types";
+import MonacoEditor from "@monaco-editor/react";
 
-const { Title, Text, Paragraph } = Typography;
-const { TextArea } = Input;
+const { Text, Paragraph } = Typography;
 
 const ToolExplorer: React.FC = () => {
   const [servers, setServers] = useState<MCPServer[]>([]);
-  const [selectedServer, setSelectedServer] = useState<string>('');
+  const [selectedServer, setSelectedServer] = useState<string>("");
   const [tools, setTools] = useState<MCPTool[]>([]);
   const [selectedTool, setSelectedTool] = useState<MCPTool | null>(null);
-  const [toolArgs, setToolArgs] = useState<string>('{}');
+  const [toolArgs, setToolArgs] = useState<string>("{}");
   const [toolResult, setToolResult] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const [executing, setExecuting] = useState(false);
@@ -32,7 +41,7 @@ const ToolExplorer: React.FC = () => {
       const serverList = await window.electronAPI.listServers();
       setServers(serverList);
     } catch (error) {
-      console.error('Failed to load servers:', error);
+      console.error("Failed to load servers:", error);
     }
   };
 
@@ -44,8 +53,8 @@ const ToolExplorer: React.FC = () => {
       setSelectedTool(null);
       setToolResult(null);
     } catch (error) {
-      console.error('Failed to load tools:', error);
-      message.error('Failed to load tools');
+      console.error("Failed to load tools:", error);
+      message.error("Failed to load tools");
     } finally {
       setLoading(false);
     }
@@ -60,13 +69,13 @@ const ToolExplorer: React.FC = () => {
       const result = await window.electronAPI.callTool(
         selectedServer,
         selectedTool.name,
-        args
+        args,
       );
       setToolResult(result);
-      message.success('Tool executed successfully');
+      message.success("Tool executed successfully");
     } catch (error) {
-      console.error('Failed to execute tool:', error);
-      message.error('Failed to execute tool: ' + (error as Error).message);
+      console.error("Failed to execute tool:", error);
+      message.error("Failed to execute tool: " + (error as Error).message);
       setToolResult({ error: (error as Error).message });
     } finally {
       setExecuting(false);
@@ -75,29 +84,29 @@ const ToolExplorer: React.FC = () => {
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
-    message.success('Copied to clipboard');
+    message.success("Copied to clipboard");
   };
 
   return (
     <div>
       <Card style={{ marginBottom: 16 }}>
-        <Space direction="vertical" style={{ width: '100%' }} size="middle">
+        <Space direction="vertical" style={{ width: "100%" }} size="middle">
           <div>
             <Text strong>Select Server:</Text>
             <Select
-              style={{ width: '100%', marginTop: 8 }}
+              style={{ width: "100%", marginTop: 8 }}
               placeholder="Select a server to explore its tools"
               value={selectedServer}
               onChange={setSelectedServer}
-              options={servers.map(s => ({ label: s.name, value: s.name }))}
+              options={servers.map((s) => ({ label: s.name, value: s.name }))}
             />
           </div>
         </Space>
       </Card>
 
       {selectedServer && (
-        <div style={{ display: 'flex', gap: 16 }}>
-          <Card title="Available Tools" style={{ flex: '0 0 300px' }}>
+        <div style={{ display: "flex", gap: 16 }}>
+          <Card title="Available Tools" style={{ flex: "0 0 300px" }}>
             {loading ? (
               <Spin />
             ) : tools.length === 0 ? (
@@ -109,12 +118,21 @@ const ToolExplorer: React.FC = () => {
                   <List.Item
                     onClick={() => {
                       setSelectedTool(tool);
-                      setToolArgs(JSON.stringify(tool.inputSchema?.properties || {}, null, 2));
+                      setToolArgs(
+                        JSON.stringify(
+                          tool.inputSchema?.properties || {},
+                          null,
+                          2,
+                        ),
+                      );
                       setToolResult(null);
                     }}
                     style={{
-                      cursor: 'pointer',
-                      background: selectedTool?.name === tool.name ? '#1890ff20' : 'transparent',
+                      cursor: "pointer",
+                      background:
+                        selectedTool?.name === tool.name
+                          ? "#1890ff20"
+                          : "transparent",
                       padding: 8,
                       borderRadius: 4,
                     }}
@@ -124,7 +142,11 @@ const ToolExplorer: React.FC = () => {
                       {tool.description && (
                         <Paragraph
                           ellipsis={{ rows: 2 }}
-                          style={{ marginBottom: 0, marginTop: 4, fontSize: 12 }}
+                          style={{
+                            marginBottom: 0,
+                            marginTop: 4,
+                            fontSize: 12,
+                          }}
                         >
                           {tool.description}
                         </Paragraph>
@@ -136,9 +158,18 @@ const ToolExplorer: React.FC = () => {
             )}
           </Card>
 
-          <Card title={selectedTool ? `Tool: ${selectedTool.name}` : 'Select a Tool'} style={{ flex: 1 }}>
+          <Card
+            title={
+              selectedTool ? `Tool: ${selectedTool.name}` : "Select a Tool"
+            }
+            style={{ flex: 1 }}
+          >
             {selectedTool ? (
-              <Space direction="vertical" style={{ width: '100%' }} size="large">
+              <Space
+                direction="vertical"
+                style={{ width: "100%" }}
+                size="large"
+              >
                 {selectedTool.description && (
                   <div>
                     <Text strong>Description:</Text>
@@ -147,7 +178,13 @@ const ToolExplorer: React.FC = () => {
                 )}
 
                 <div>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      marginBottom: 8,
+                    }}
+                  >
                     <Text strong>Arguments (JSON):</Text>
                     <Button
                       size="small"
@@ -162,7 +199,7 @@ const ToolExplorer: React.FC = () => {
                     language="json"
                     theme="vs-dark"
                     value={toolArgs}
-                    onChange={(value) => setToolArgs(value || '{}')}
+                    onChange={(value) => setToolArgs(value || "{}")}
                     options={{
                       minimap: { enabled: false },
                       fontSize: 12,
@@ -182,12 +219,20 @@ const ToolExplorer: React.FC = () => {
 
                 {toolResult && (
                   <div>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        marginBottom: 8,
+                      }}
+                    >
                       <Text strong>Result:</Text>
                       <Button
                         size="small"
                         icon={<CopyOutlined />}
-                        onClick={() => copyToClipboard(JSON.stringify(toolResult, null, 2))}
+                        onClick={() =>
+                          copyToClipboard(JSON.stringify(toolResult, null, 2))
+                        }
                       >
                         Copy
                       </Button>

--- a/src/renderer/data/mcp-servers.ts
+++ b/src/renderer/data/mcp-servers.ts
@@ -31,139 +31,160 @@ export interface MCPServerTemplate {
 export const MCP_SERVERS: MCPServerTemplate[] = [
   // File System & Storage
   {
-    id: 'filesystem',
-    name: 'FileSystem',
-    category: 'File Management',
-    description: 'Access and manipulate files and directories on the local filesystem',
+    id: "filesystem",
+    name: "FileSystem",
+    category: "File Management",
+    description:
+      "Access and manipulate files and directories on the local filesystem",
     official: true,
     package: {
-      npx: '@modelcontextprotocol/server-filesystem',
+      npx: "@modelcontextprotocol/server-filesystem",
     },
     tools: [
-      { name: 'read_file', description: 'Read contents of a file' },
-      { name: 'write_file', description: 'Write content to a file' },
-      { name: 'list_directory', description: 'List files in a directory' },
-      { name: 'create_directory', description: 'Create a new directory' },
-      { name: 'delete_file', description: 'Delete a file' },
-      { name: 'move_file', description: 'Move or rename a file' },
-      { name: 'search_files', description: 'Search for files by pattern' },
-      { name: 'get_file_info', description: 'Get metadata about a file' },
+      { name: "read_file", description: "Read contents of a file" },
+      { name: "write_file", description: "Write content to a file" },
+      { name: "list_directory", description: "List files in a directory" },
+      { name: "create_directory", description: "Create a new directory" },
+      { name: "delete_file", description: "Delete a file" },
+      { name: "move_file", description: "Move or rename a file" },
+      { name: "search_files", description: "Search for files by pattern" },
+      { name: "get_file_info", description: "Get metadata about a file" },
     ],
     arguments: [
       {
-        name: '--directory',
-        description: 'Base directory for filesystem operations',
+        name: "--directory",
+        description: "Base directory for filesystem operations",
         required: true,
-        example: '~/Documents',
+        example: "~/Documents",
       },
     ],
   },
   {
-    id: 'memory',
-    name: 'Memory',
-    category: 'Knowledge Management',
-    description: 'Knowledge graph-based persistent memory for storing and retrieving information',
+    id: "memory",
+    name: "Memory",
+    category: "Knowledge Management",
+    description:
+      "Knowledge graph-based persistent memory for storing and retrieving information",
     official: true,
     package: {
-      npx: '@modelcontextprotocol/server-memory',
+      npx: "@modelcontextprotocol/server-memory",
     },
     tools: [
-      { name: 'create_entities', description: 'Create new entities in the knowledge graph' },
-      { name: 'create_relations', description: 'Create relationships between entities' },
-      { name: 'search_entities', description: 'Search for entities' },
-      { name: 'search_relations', description: 'Search for relationships' },
-      { name: 'get_entity', description: 'Get details of a specific entity' },
-      { name: 'get_relation', description: 'Get details of a specific relation' },
-      { name: 'delete_entity', description: 'Delete an entity' },
-      { name: 'delete_relation', description: 'Delete a relationship' },
-      { name: 'open_nodes', description: 'Get nodes connected to an entity' },
+      {
+        name: "create_entities",
+        description: "Create new entities in the knowledge graph",
+      },
+      {
+        name: "create_relations",
+        description: "Create relationships between entities",
+      },
+      { name: "search_entities", description: "Search for entities" },
+      { name: "search_relations", description: "Search for relationships" },
+      { name: "get_entity", description: "Get details of a specific entity" },
+      {
+        name: "get_relation",
+        description: "Get details of a specific relation",
+      },
+      { name: "delete_entity", description: "Delete an entity" },
+      { name: "delete_relation", description: "Delete a relationship" },
+      { name: "open_nodes", description: "Get nodes connected to an entity" },
     ],
   },
 
   // Development Tools
   {
-    id: 'github',
-    name: 'GitHub',
-    category: 'Development',
-    description: 'Interact with GitHub repositories, issues, pull requests, and more',
+    id: "github",
+    name: "GitHub",
+    category: "Development",
+    description:
+      "Interact with GitHub repositories, issues, pull requests, and more",
     official: true,
     package: {
-      npx: '@modelcontextprotocol/server-github',
+      npx: "@modelcontextprotocol/server-github",
     },
     tools: [
-      { name: 'create_repository', description: 'Create a new GitHub repository' },
-      { name: 'list_repositories', description: 'List repositories for a user/org' },
-      { name: 'create_issue', description: 'Create a new issue' },
-      { name: 'list_issues', description: 'List issues in a repository' },
-      { name: 'update_issue', description: 'Update an existing issue' },
-      { name: 'add_issue_comment', description: 'Add a comment to an issue' },
-      { name: 'create_pull_request', description: 'Create a new pull request' },
-      { name: 'list_pull_requests', description: 'List pull requests' },
+      {
+        name: "create_repository",
+        description: "Create a new GitHub repository",
+      },
+      {
+        name: "list_repositories",
+        description: "List repositories for a user/org",
+      },
+      { name: "create_issue", description: "Create a new issue" },
+      { name: "list_issues", description: "List issues in a repository" },
+      { name: "update_issue", description: "Update an existing issue" },
+      { name: "add_issue_comment", description: "Add a comment to an issue" },
+      { name: "create_pull_request", description: "Create a new pull request" },
+      { name: "list_pull_requests", description: "List pull requests" },
     ],
     environmentVariables: [
       {
-        name: 'GITHUB_TOKEN',
-        description: 'GitHub personal access token',
+        name: "GITHUB_TOKEN",
+        description: "GitHub personal access token",
         required: true,
-        example: 'ghp_...',
+        example: "ghp_...",
       },
     ],
   },
   {
-    id: 'gitlab',
-    name: 'GitLab',
-    category: 'Development',
-    description: 'Interact with GitLab projects, issues, and merge requests',
+    id: "gitlab",
+    name: "GitLab",
+    category: "Development",
+    description: "Interact with GitLab projects, issues, and merge requests",
     package: {
-      npx: '@modelcontextprotocol/server-gitlab',
+      npx: "@modelcontextprotocol/server-gitlab",
     },
     tools: [
-      { name: 'create_project', description: 'Create a new GitLab project' },
-      { name: 'list_projects', description: 'List projects' },
-      { name: 'create_issue', description: 'Create a new issue' },
-      { name: 'create_merge_request', description: 'Create a merge request' },
+      { name: "create_project", description: "Create a new GitLab project" },
+      { name: "list_projects", description: "List projects" },
+      { name: "create_issue", description: "Create a new issue" },
+      { name: "create_merge_request", description: "Create a merge request" },
     ],
     environmentVariables: [
       {
-        name: 'GITLAB_TOKEN',
-        description: 'GitLab personal access token',
+        name: "GITLAB_TOKEN",
+        description: "GitLab personal access token",
         required: true,
       },
       {
-        name: 'GITLAB_URL',
-        description: 'GitLab instance URL',
+        name: "GITLAB_URL",
+        description: "GitLab instance URL",
         required: false,
-        example: 'https://gitlab.com',
+        example: "https://gitlab.com",
       },
     ],
   },
 
   // Communication
   {
-    id: 'slack',
-    name: 'Slack',
-    category: 'Communication',
-    description: 'Send messages and interact with Slack workspaces',
+    id: "slack",
+    name: "Slack",
+    category: "Communication",
+    description: "Send messages and interact with Slack workspaces",
     package: {
-      npx: '@modelcontextprotocol/server-slack',
+      npx: "@modelcontextprotocol/server-slack",
     },
     tools: [
-      { name: 'send_message', description: 'Send a message to a channel' },
-      { name: 'list_channels', description: 'List available channels' },
-      { name: 'get_channel_history', description: 'Get message history from a channel' },
-      { name: 'add_reaction', description: 'Add a reaction to a message' },
-      { name: 'create_channel', description: 'Create a new channel' },
+      { name: "send_message", description: "Send a message to a channel" },
+      { name: "list_channels", description: "List available channels" },
+      {
+        name: "get_channel_history",
+        description: "Get message history from a channel",
+      },
+      { name: "add_reaction", description: "Add a reaction to a message" },
+      { name: "create_channel", description: "Create a new channel" },
     ],
     environmentVariables: [
       {
-        name: 'SLACK_BOT_TOKEN',
-        description: 'Slack bot token',
+        name: "SLACK_BOT_TOKEN",
+        description: "Slack bot token",
         required: true,
-        example: 'xoxb-...',
+        example: "xoxb-...",
       },
       {
-        name: 'SLACK_TEAM_ID',
-        description: 'Slack workspace/team ID',
+        name: "SLACK_TEAM_ID",
+        description: "Slack workspace/team ID",
         required: true,
       },
     ],
@@ -171,121 +192,127 @@ export const MCP_SERVERS: MCPServerTemplate[] = [
 
   // Databases
   {
-    id: 'sqlite',
-    name: 'SQLite',
-    category: 'Database',
-    description: 'Execute SQL queries and manage SQLite databases',
+    id: "sqlite",
+    name: "SQLite",
+    category: "Database",
+    description: "Execute SQL queries and manage SQLite databases",
     official: true,
     package: {
-      uvx: 'mcp-server-sqlite@latest',
+      uvx: "mcp-server-sqlite@latest",
     },
     tools: [
-      { name: 'read_query', description: 'Execute a SELECT query' },
-      { name: 'write_query', description: 'Execute INSERT/UPDATE/DELETE queries' },
-      { name: 'create_table', description: 'Create a new table' },
-      { name: 'list_tables', description: 'List all tables in the database' },
-      { name: 'describe_table', description: 'Get table schema' },
-      { name: 'append_insight', description: 'Add analytical insights' },
+      { name: "read_query", description: "Execute a SELECT query" },
+      {
+        name: "write_query",
+        description: "Execute INSERT/UPDATE/DELETE queries",
+      },
+      { name: "create_table", description: "Create a new table" },
+      { name: "list_tables", description: "List all tables in the database" },
+      { name: "describe_table", description: "Get table schema" },
+      { name: "append_insight", description: "Add analytical insights" },
     ],
     arguments: [
       {
-        name: '--db-path',
-        description: 'Path to SQLite database file',
+        name: "--db-path",
+        description: "Path to SQLite database file",
         required: true,
-        example: './data.db',
+        example: "./data.db",
       },
     ],
   },
   {
-    id: 'postgresql',
-    name: 'PostgreSQL',
-    category: 'Database',
-    description: 'Connect to and query PostgreSQL databases',
+    id: "postgresql",
+    name: "PostgreSQL",
+    category: "Database",
+    description: "Connect to and query PostgreSQL databases",
     package: {
-      npx: '@modelcontextprotocol/server-postgres',
-      uvx: 'mcp-server-postgres@latest',
+      npx: "@modelcontextprotocol/server-postgres",
+      uvx: "mcp-server-postgres@latest",
     },
     tools: [
-      { name: 'query', description: 'Execute SQL queries' },
-      { name: 'list_tables', description: 'List database tables' },
-      { name: 'describe_table', description: 'Get table structure' },
+      { name: "query", description: "Execute SQL queries" },
+      { name: "list_tables", description: "List database tables" },
+      { name: "describe_table", description: "Get table structure" },
     ],
     environmentVariables: [
       {
-        name: 'DATABASE_URL',
-        description: 'PostgreSQL connection string',
+        name: "DATABASE_URL",
+        description: "PostgreSQL connection string",
         required: true,
-        example: 'postgresql://user:pass@localhost:5432/dbname',
+        example: "postgresql://user:pass@localhost:5432/dbname",
       },
     ],
   },
 
   // AI & Web
   {
-    id: 'brave-search',
-    name: 'Brave Search',
-    category: 'Web & Search',
-    description: 'Search the web using Brave Search API',
+    id: "brave-search",
+    name: "Brave Search",
+    category: "Web & Search",
+    description: "Search the web using Brave Search API",
     package: {
-      npx: '@modelcontextprotocol/server-brave-search',
+      npx: "@modelcontextprotocol/server-brave-search",
     },
     tools: [
-      { name: 'brave_web_search', description: 'Search the web with Brave' },
-      { name: 'brave_local_search', description: 'Search for local businesses' },
+      { name: "brave_web_search", description: "Search the web with Brave" },
+      {
+        name: "brave_local_search",
+        description: "Search for local businesses",
+      },
     ],
     environmentVariables: [
       {
-        name: 'BRAVE_API_KEY',
-        description: 'Brave Search API key',
+        name: "BRAVE_API_KEY",
+        description: "Brave Search API key",
         required: true,
       },
     ],
   },
   {
-    id: 'fetch',
-    name: 'Web Fetch',
-    category: 'Web & Search',
-    description: 'Fetch and extract content from web pages',
+    id: "fetch",
+    name: "Web Fetch",
+    category: "Web & Search",
+    description: "Fetch and extract content from web pages",
     package: {
-      npx: '@modelcontextprotocol/server-fetch',
+      npx: "@modelcontextprotocol/server-fetch",
     },
     tools: [
-      { name: 'fetch', description: 'Fetch content from a URL' },
-      { name: 'extract', description: 'Extract structured data from HTML' },
+      { name: "fetch", description: "Fetch content from a URL" },
+      { name: "extract", description: "Extract structured data from HTML" },
     ],
   },
 
   // Cloud Storage
   {
-    id: 'google-drive',
-    name: 'Google Drive',
-    category: 'Cloud Storage',
-    description: 'Access and manage files in Google Drive',
+    id: "google-drive",
+    name: "Google Drive",
+    category: "Cloud Storage",
+    description: "Access and manage files in Google Drive",
     package: {
-      npx: '@modelcontextprotocol/server-google-drive',
+      npx: "@modelcontextprotocol/server-google-drive",
     },
     tools: [
-      { name: 'list_files', description: 'List files in Drive' },
-      { name: 'read_file', description: 'Read file contents' },
-      { name: 'create_file', description: 'Create a new file' },
-      { name: 'update_file', description: 'Update file contents' },
-      { name: 'move_file', description: 'Move file to different folder' },
-      { name: 'search_files', description: 'Search for files' },
+      { name: "list_files", description: "List files in Drive" },
+      { name: "read_file", description: "Read file contents" },
+      { name: "create_file", description: "Create a new file" },
+      { name: "update_file", description: "Update file contents" },
+      { name: "move_file", description: "Move file to different folder" },
+      { name: "search_files", description: "Search for files" },
     ],
     environmentVariables: [
       {
-        name: 'GOOGLE_DRIVE_CLIENT_ID',
-        description: 'Google OAuth client ID',
+        name: "GOOGLE_DRIVE_CLIENT_ID",
+        description: "Google OAuth client ID",
         required: true,
       },
       {
-        name: 'GOOGLE_DRIVE_CLIENT_SECRET',
-        description: 'Google OAuth client secret',
+        name: "GOOGLE_DRIVE_CLIENT_SECRET",
+        description: "Google OAuth client secret",
         required: true,
       },
       {
-        name: 'GOOGLE_DRIVE_REFRESH_TOKEN',
-        description: 'Google OAuth refresh token',
+        name: "GOOGLE_DRIVE_REFRESH_TOKEN",
+        description: "Google OAuth refresh token",
         required: true,
       },
     ],
@@ -293,92 +320,92 @@ export const MCP_SERVERS: MCPServerTemplate[] = [
 
   // Time & Utilities
   {
-    id: 'time',
-    name: 'Time',
-    category: 'Utilities',
-    description: 'Get current time and timezone information',
+    id: "time",
+    name: "Time",
+    category: "Utilities",
+    description: "Get current time and timezone information",
     package: {
-      uvx: 'mcp-server-time@latest',
+      uvx: "mcp-server-time@latest",
     },
     tools: [
-      { name: 'get_current_time', description: 'Get the current time' },
-      { name: 'convert_time', description: 'Convert time between timezones' },
+      { name: "get_current_time", description: "Get the current time" },
+      { name: "convert_time", description: "Convert time between timezones" },
     ],
     arguments: [
       {
-        name: '--local-timezone',
-        description: 'Set local timezone',
+        name: "--local-timezone",
+        description: "Set local timezone",
         required: false,
-        example: 'America/New_York',
+        example: "America/New_York",
       },
     ],
   },
 
   // Note-taking
   {
-    id: 'obsidian',
-    name: 'Obsidian',
-    category: 'Note-taking',
-    description: 'Interact with Obsidian vaults and notes',
+    id: "obsidian",
+    name: "Obsidian",
+    category: "Note-taking",
+    description: "Interact with Obsidian vaults and notes",
     package: {
-      npx: '@modelcontextprotocol/server-obsidian',
+      npx: "@modelcontextprotocol/server-obsidian",
     },
     tools: [
-      { name: 'read_note', description: 'Read a note from vault' },
-      { name: 'create_note', description: 'Create a new note' },
-      { name: 'update_note', description: 'Update an existing note' },
-      { name: 'list_notes', description: 'List notes in vault' },
-      { name: 'search_notes', description: 'Search notes by content' },
+      { name: "read_note", description: "Read a note from vault" },
+      { name: "create_note", description: "Create a new note" },
+      { name: "update_note", description: "Update an existing note" },
+      { name: "list_notes", description: "List notes in vault" },
+      { name: "search_notes", description: "Search notes by content" },
     ],
     arguments: [
       {
-        name: '--vault-path',
-        description: 'Path to Obsidian vault',
+        name: "--vault-path",
+        description: "Path to Obsidian vault",
         required: true,
-        example: '~/Documents/ObsidianVault',
+        example: "~/Documents/ObsidianVault",
       },
     ],
   },
   {
-    id: 'notion',
-    name: 'Notion',
-    category: 'Note-taking',
-    description: 'Access and manage Notion pages and databases',
+    id: "notion",
+    name: "Notion",
+    category: "Note-taking",
+    description: "Access and manage Notion pages and databases",
     package: {
-      npx: '@modelcontextprotocol/server-notion',
+      npx: "@modelcontextprotocol/server-notion",
     },
     tools: [
-      { name: 'search_pages', description: 'Search Notion pages' },
-      { name: 'read_page', description: 'Read page content' },
-      { name: 'create_page', description: 'Create a new page' },
-      { name: 'update_page', description: 'Update page content' },
-      { name: 'query_database', description: 'Query a Notion database' },
+      { name: "search_pages", description: "Search Notion pages" },
+      { name: "read_page", description: "Read page content" },
+      { name: "create_page", description: "Create a new page" },
+      { name: "update_page", description: "Update page content" },
+      { name: "query_database", description: "Query a Notion database" },
     ],
     environmentVariables: [
       {
-        name: 'NOTION_API_KEY',
-        description: 'Notion integration token',
+        name: "NOTION_API_KEY",
+        description: "Notion integration token",
         required: true,
-        example: 'secret_...',
+        example: "secret_...",
       },
     ],
   },
 
   // Development Tools
   {
-    id: 'puppeteer',
-    name: 'Puppeteer',
-    category: 'Web Automation',
-    description: 'Control headless Chrome for web scraping and automation',
+    id: "puppeteer",
+    name: "Puppeteer",
+    category: "Web Automation",
+    description: "Control headless Chrome for web scraping and automation",
     package: {
-      npx: '@modelcontextprotocol/server-puppeteer',
+      npx: "@modelcontextprotocol/server-puppeteer",
     },
     tools: [
-      { name: 'navigate', description: 'Navigate to a URL' },
-      { name: 'screenshot', description: 'Take a screenshot' },
-      { name: 'click', description: 'Click an element' },
-      { name: 'type', description: 'Type text into an input' },
-      { name: 'evaluate', description: 'Execute JavaScript in page' },
+      { name: "navigate", description: "Navigate to a URL" },
+      { name: "screenshot", description: "Take a screenshot" },
+      { name: "click", description: "Click an element" },
+      { name: "type", description: "Type text into an input" },
+      { name: "evaluate", description: "Execute JavaScript in page" },
     ],
   },
 ];
@@ -386,27 +413,29 @@ export const MCP_SERVERS: MCPServerTemplate[] = [
 // Helper function to get servers by category
 export function getServersByCategory(): Record<string, MCPServerTemplate[]> {
   const categories: Record<string, MCPServerTemplate[]> = {};
-  
-  MCP_SERVERS.forEach(server => {
+
+  MCP_SERVERS.forEach((server) => {
     if (!categories[server.category]) {
       categories[server.category] = [];
     }
     categories[server.category].push(server);
   });
-  
+
   return categories;
 }
 
 // Helper function to search servers
 export function searchServers(query: string): MCPServerTemplate[] {
   const lowerQuery = query.toLowerCase();
-  return MCP_SERVERS.filter(server => 
-    server.name.toLowerCase().includes(lowerQuery) ||
-    server.description.toLowerCase().includes(lowerQuery) ||
-    server.category.toLowerCase().includes(lowerQuery) ||
-    server.tools.some(tool => 
-      tool.name.toLowerCase().includes(lowerQuery) ||
-      tool.description.toLowerCase().includes(lowerQuery)
-    )
+  return MCP_SERVERS.filter(
+    (server) =>
+      server.name.toLowerCase().includes(lowerQuery) ||
+      server.description.toLowerCase().includes(lowerQuery) ||
+      server.category.toLowerCase().includes(lowerQuery) ||
+      server.tools.some(
+        (tool) =>
+          tool.name.toLowerCase().includes(lowerQuery) ||
+          tool.description.toLowerCase().includes(lowerQuery),
+      ),
   );
 }

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { ConfigProvider, theme } from 'antd';
-import App from './App';
-import './styles/global.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { ConfigProvider, theme } from "antd";
+import App from "./App";
+import "./styles/global.css";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 
 root.render(
@@ -14,12 +14,12 @@ root.render(
       theme={{
         algorithm: theme.darkAlgorithm,
         token: {
-          colorPrimary: '#1890ff',
+          colorPrimary: "#1890ff",
           borderRadius: 6,
         },
       }}
     >
       <App />
     </ConfigProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -5,9 +5,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: #141414;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,8 +2,8 @@ export interface MCPServer {
   name: string;
   package: string;
   tools: string[];
-  status: 'running' | 'stopped' | 'error' | 'initializing';
-  health?: 'healthy' | 'unhealthy' | 'unknown';
+  status: "running" | "stopped" | "error" | "initializing";
+  health?: "healthy" | "unhealthy" | "unknown";
 }
 
 export interface MCPTool {
@@ -31,29 +31,29 @@ export interface ConfigEntry {
 
 export interface IpcChannels {
   // Daemon management
-  'daemon:start': () => Promise<DaemonStatus>;
-  'daemon:stop': () => Promise<void>;
-  'daemon:status': () => Promise<DaemonStatus>;
-  'daemon:logs': () => Promise<string[]>;
-  
+  "daemon:start": () => Promise<DaemonStatus>;
+  "daemon:stop": () => Promise<void>;
+  "daemon:status": () => Promise<DaemonStatus>;
+  "daemon:logs": () => Promise<string[]>;
+
   // Server management
-  'servers:list': () => Promise<MCPServer[]>;
-  'servers:add': (name: string, packageName: string) => Promise<void>;
-  'servers:remove': (name: string) => Promise<void>;
-  'servers:tools': (name: string) => Promise<MCPTool[]>;
-  
+  "servers:list": () => Promise<MCPServer[]>;
+  "servers:add": (name: string, packageName: string) => Promise<void>;
+  "servers:remove": (name: string) => Promise<void>;
+  "servers:tools": (name: string) => Promise<MCPTool[]>;
+
   // Tool execution
-  'tool:call': (server: string, tool: string, args: any) => Promise<any>;
-  
+  "tool:call": (server: string, tool: string, args: any) => Promise<any>;
+
   // Configuration
-  'config:load': () => Promise<ConfigEntry[]>;
-  'config:save': (config: ConfigEntry[]) => Promise<void>;
-  'config:export': () => Promise<string>;
+  "config:load": () => Promise<ConfigEntry[]>;
+  "config:save": (config: ConfigEntry[]) => Promise<void>;
+  "config:export": () => Promise<string>;
 }
 
 export interface LogEntry {
   timestamp: string;
-  level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+  level: "DEBUG" | "INFO" | "WARN" | "ERROR";
   message: string;
   source?: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,10 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "baseUrl": "./src",
     "paths": {


### PR DESCRIPTION
## Summary

- Adds ESLint v9 with flat config and typescript-eslint, matching the tooling from [mcpd-sdk-javascript](https://github.com/mozilla-ai/mcpd-sdk-javascript)
- Adds Prettier for consistent code formatting across the codebase
- Tightens TypeScript compiler options (`noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`)
- Fixes all unused imports and variables found by the new rules
- Adds `lint`, `lint:fix`, `format`, `format:check`, `typecheck`, and `check` scripts
- Updates CI to run the full lint pipeline instead of bare `tsc --noEmit`

`no-explicit-any` is set to `warn` for now — tightening it to `error` can be done incrementally in follow-up PRs.

## Test plan

- [x] `npm run lint` passes (0 errors, 47 `no-explicit-any` warnings)
- [x] `npm run typecheck` passes clean
- [x] `npm run build` compiles all three webpack targets
- [x] `npm run format:check` passes