### PR TITLE
feat: show app and mcpd daemon version info

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { app, ipcMain } from "electron";
 import { McpdManager } from "./mcpd-manager";
 
 export function setupIPC(mcpdManager: McpdManager) {
@@ -35,6 +35,14 @@ export function setupIPC(mcpdManager: McpdManager) {
 
   ipcMain.handle("daemon:logs", async (_, lines: number = 100) => {
     return await mcpdManager.getLogs(lines);
+  });
+
+  ipcMain.handle("daemon:version", async () => {
+    return await mcpdManager.getMcpdVersion();
+  });
+
+  ipcMain.handle("app:version", () => {
+    return app.getVersion();
   });
 
   // Server management
@@ -101,6 +109,23 @@ export function setupIPC(mcpdManager: McpdManager) {
   ipcMain.handle("config:export", async () => {
     const config = await mcpdManager.loadConfig();
     return JSON.stringify(config, null, 2);
+  });
+
+  // Secrets management (runtime env/args for ~/.config/mcpd/secrets.dev.toml).
+  ipcMain.handle(
+    "secrets:save-server",
+    async (
+      _,
+      serverName: string,
+      env: Record<string, string>,
+      args: string[],
+    ) => {
+      return await mcpdManager.saveServerSecrets(serverName, env, args);
+    },
+  );
+
+  ipcMain.handle("secrets:path", () => {
+    return mcpdManager.getSecretsPath();
   });
 
   // Connect functionality - simplified one-click setup using mcpd-proxy.

--- a/src/main/mcpd-manager.ts
+++ b/src/main/mcpd-manager.ts
@@ -1,6 +1,7 @@
 import { spawn, ChildProcess } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
 import { McpdClient } from "@mozilla-ai/mcpd";
 import * as TOML from "@iarna/toml";
 import { app } from "electron";
@@ -11,7 +12,9 @@ export class McpdManager {
   private mcpdClient: McpdClient;
   private logPath: string;
   private configPath: string;
+  private secretsPath: string;
   private mcpdPath: string;
+  private cachedMcpdVersion: string | null = null;
 
   constructor() {
     this.mcpdClient = new McpdClient({
@@ -23,6 +26,11 @@ export class McpdManager {
     const userDataPath = app.getPath("userData");
     this.logPath = path.join(userDataPath, "mcpd.log");
     this.configPath = path.join(userDataPath, ".mcpd.toml");
+
+    // Secrets file at the XDG config path used by mcpd in --dev mode.
+    const configHome =
+      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+    this.secretsPath = path.join(configHome, "mcpd", "secrets.dev.toml");
 
     // Find mcpd binary path.
     this.mcpdPath = this.findMcpdPath();
@@ -89,12 +97,22 @@ export class McpdManager {
         this.initConfig();
       }
 
+      // Ensure the secrets file exists so --runtime-file doesn't fail on first launch.
+      if (!fs.existsSync(this.secretsPath)) {
+        const secretsDir = path.dirname(this.secretsPath);
+        if (!fs.existsSync(secretsDir)) {
+          fs.mkdirSync(secretsDir, { recursive: true });
+        }
+        fs.writeFileSync(this.secretsPath, "");
+      }
+
       console.log(`[${this.constructor.name}] Spawning daemon with args:`, [
         "daemon",
         "--dev",
         "--log-level=DEBUG",
         `--log-path=${this.logPath}`,
         `--config-file=${this.configPath}`,
+        `--runtime-file=${this.secretsPath}`,
       ]);
 
       try {
@@ -140,6 +158,7 @@ export class McpdManager {
             "--log-level=DEBUG",
             `--log-path=${this.logPath}`,
             `--config-file=${this.configPath}`,
+            `--runtime-file=${this.secretsPath}`,
           ],
           {
             cwd: app.getPath("userData"),
@@ -288,6 +307,7 @@ export class McpdManager {
   }
 
   async stopDaemon(): Promise<void> {
+    this.cachedMcpdVersion = null;
     if (this.daemonProcess) {
       return new Promise((resolve) => {
         this.daemonProcess!.on("exit", () => {
@@ -493,8 +513,10 @@ export class McpdManager {
     name: string;
     package: string;
     tools?: string[];
-    env?: Record<string, string>;
-    args?: string[];
+    required_env?: string[];
+    required_args?: string[];
+    required_args_bool?: string[];
+    required_args_positional?: string[];
   }): Promise<void> {
     console.log(
       `[${this.constructor.name}] addServerToConfig called with:`,
@@ -516,7 +538,7 @@ export class McpdManager {
       throw new Error(`Server with name '${server.name}' already exists`);
     }
 
-    // Build new server entry matching mcpd's expected TOML format.
+    // Build new server entry matching mcpd's ServerEntry TOML format.
     const newServer: any = {
       name: server.name,
       package: server.package,
@@ -525,11 +547,20 @@ export class McpdManager {
     if (server.tools && server.tools.length > 0) {
       newServer.tools = server.tools;
     }
-    if (server.env && Object.keys(server.env).length > 0) {
-      newServer.env = server.env;
+    if (server.required_env && server.required_env.length > 0) {
+      newServer.required_env = server.required_env;
     }
-    if (server.args && server.args.length > 0) {
-      newServer.args = server.args;
+    if (server.required_args && server.required_args.length > 0) {
+      newServer.required_args = server.required_args;
+    }
+    if (server.required_args_bool && server.required_args_bool.length > 0) {
+      newServer.required_args_bool = server.required_args_bool;
+    }
+    if (
+      server.required_args_positional &&
+      server.required_args_positional.length > 0
+    ) {
+      newServer.required_args_positional = server.required_args_positional;
     }
 
     // Add to config.
@@ -590,6 +621,97 @@ export class McpdManager {
       await this.startDaemon();
       console.log(`[${this.constructor.name}] Daemon restarted successfully`);
     }
+  }
+
+  async getMcpdVersion(): Promise<string> {
+    if (this.cachedMcpdVersion) return this.cachedMcpdVersion;
+
+    return new Promise((resolve) => {
+      const proc = spawn(this.mcpdPath, ["version"], {
+        cwd: app.getPath("userData"),
+      });
+
+      let output = "";
+      let resolved = false;
+      const done = (value: string) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timer);
+        if (value !== "unknown") this.cachedMcpdVersion = value;
+        resolve(value);
+      };
+
+      const timer = setTimeout(() => {
+        proc.kill();
+        done("unknown");
+      }, 5000);
+
+      proc.stdout?.on("data", (data) => {
+        output += data.toString();
+      });
+
+      proc.on("exit", (code) => {
+        done(code === 0 && output.trim() ? output.trim() : "unknown");
+      });
+
+      proc.on("error", () => {
+        done("unknown");
+      });
+    });
+  }
+
+  async saveServerSecrets(
+    serverName: string,
+    env: Record<string, string>,
+    args: string[],
+  ): Promise<void> {
+    // Ensure the config directory exists.
+    const secretsDir = path.dirname(this.secretsPath);
+    if (!fs.existsSync(secretsDir)) {
+      fs.mkdirSync(secretsDir, { recursive: true });
+    }
+
+    // Load existing secrets or start fresh.
+    let secrets: any = {};
+    if (fs.existsSync(this.secretsPath)) {
+      try {
+        const content = fs.readFileSync(this.secretsPath, "utf-8");
+        secrets = TOML.parse(content);
+      } catch (err) {
+        console.error(
+          `[${this.constructor.name}] Failed to parse ${this.secretsPath}, starting fresh:`,
+          err,
+        );
+      }
+    }
+
+    if (!secrets.servers) {
+      secrets.servers = {};
+    }
+
+    // Build the server section.
+    const serverSection: any = {};
+    if (args.length > 0) {
+      serverSection.args = args;
+    }
+    const nonEmptyEnv = Object.fromEntries(
+      Object.entries(env).filter(([, v]) => v !== ""),
+    );
+    if (Object.keys(nonEmptyEnv).length > 0) {
+      serverSection.env = nonEmptyEnv;
+    }
+
+    secrets.servers[serverName] = serverSection;
+
+    fs.writeFileSync(this.secretsPath, TOML.stringify(secrets));
+    console.log(
+      `[${this.constructor.name}] Server secrets saved to:`,
+      this.secretsPath,
+    );
+  }
+
+  getSecretsPath(): string {
+    return this.secretsPath;
   }
 
   async getConfiguredServers(): Promise<any[]> {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,6 +18,8 @@ try {
       return ipcRenderer.invoke("daemon:status");
     },
     getDaemonLogs: (lines?: number) => ipcRenderer.invoke("daemon:logs", lines),
+    getDaemonVersion: () => ipcRenderer.invoke("daemon:version"),
+    getAppVersion: () => ipcRenderer.invoke("app:version"),
 
     // Server management
     listServers: () => ipcRenderer.invoke("servers:list"),
@@ -26,6 +28,14 @@ try {
     searchServers: (query: string) =>
       ipcRenderer.invoke("servers:search", query),
     getServerTools: (name: string) => ipcRenderer.invoke("servers:tools", name),
+
+    // Secrets management (runtime env/args).
+    saveServerSecrets: (
+      serverName: string,
+      env: Record<string, string>,
+      args: string[],
+    ) => ipcRenderer.invoke("secrets:save-server", serverName, env, args),
+    getSecretsPath: () => ipcRenderer.invoke("secrets:path") as Promise<string>,
 
     // Tool execution
     callTool: (server: string, tool: string, args: any) =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,11 +26,19 @@ declare global {
       stopDaemon: () => Promise<void>;
       getDaemonStatus: () => Promise<DaemonStatus>;
       getDaemonLogs: (lines?: number) => Promise<string[]>;
+      getDaemonVersion: () => Promise<string>;
+      getAppVersion: () => Promise<string>;
       listServers: () => Promise<any[]>;
       addServer: (server: any) => Promise<void>;
       removeServer: (name: string) => Promise<void>;
       searchServers: (query: string) => Promise<RegistryServer[]>;
       getServerTools: (name: string) => Promise<any[]>;
+      saveServerSecrets: (
+        serverName: string,
+        env: Record<string, string>,
+        args: string[],
+      ) => Promise<void>;
+      getSecretsPath: () => Promise<string>;
       callTool: (server: string, tool: string, args: any) => Promise<any>;
       loadConfig: () => Promise<any>;
       saveConfig: (content: string) => Promise<void>;
@@ -54,11 +62,16 @@ const App: React.FC = () => {
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>({
     running: false,
   });
+  const [appVersion, setAppVersion] = useState<string>("");
 
   useEffect(() => {
     checkDaemonStatus();
     const interval = setInterval(checkDaemonStatus, 5000);
     return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    window.electronAPI.getAppVersion().then(setAppVersion).catch(console.error);
   }, []);
 
   const checkDaemonStatus = async () => {
@@ -192,6 +205,21 @@ const App: React.FC = () => {
             Connect
           </Menu.Item>
         </Menu>
+        {!collapsed && appVersion && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: 48,
+              left: 0,
+              right: 0,
+              textAlign: "center",
+              color: "rgba(255,255,255,0.45)",
+              fontSize: 12,
+            }}
+          >
+            v{appVersion}
+          </div>
+        )}
       </Sider>
       <Layout>
         <Header

--- a/src/renderer/components/AddServerModal.tsx
+++ b/src/renderer/components/AddServerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
   Modal,
   Form,
@@ -8,6 +8,7 @@ import {
   Space,
   Tabs,
   Tag,
+  Switch,
   Checkbox,
   Divider,
   List,
@@ -18,7 +19,6 @@ import {
   Col,
   Collapse,
   Empty,
-  Switch,
 } from "antd";
 import {
   CodeOutlined,
@@ -189,80 +189,95 @@ function extractFilterOptions(servers: TaggedServer[]) {
   };
 }
 
-// Shared argument processing: extracts env, positional, and named args from form values.
+// Processed arguments matching mcpd's ServerEntry TOML fields.
+interface ProcessedArgs {
+  requiredEnv: string[];
+  requiredArgs: string[];
+  requiredArgsBool: string[];
+  requiredArgsPositional: string[];
+}
+
+// Shared argument processing: maps registry arguments to mcpd config fields.
 function processArguments(
   serverArgs: Record<string, RegistryArgument> | undefined,
-  argValues: Record<string, string>,
-): { envVars: Record<string, string>; args: string[] } {
-  const envVars: Record<string, string> = {};
-  const positionalArgs: { position: number; value: string }[] = [];
-  const namedArgs: string[] = [];
+): ProcessedArgs {
+  const requiredEnv: string[] = [];
+  const requiredArgs: string[] = [];
+  const requiredArgsBool: string[] = [];
+  const positional: { position: number; name: string }[] = [];
 
-  for (const [key, arg] of Object.entries(serverArgs ?? {})) {
-    const value = argValues[key] ?? "";
-    if (!value && !arg.required) continue;
+  for (const [, arg] of Object.entries(serverArgs ?? {})) {
+    if (!arg.required) continue;
 
     switch (arg.type) {
       case "environment":
-        envVars[arg.name] = value;
+        requiredEnv.push(arg.name);
         break;
       case "argument":
-        namedArgs.push(arg.name, value);
+        requiredArgs.push(arg.name);
         break;
       case "argument_bool":
-        if (value === "true") namedArgs.push(arg.name);
+        requiredArgsBool.push(arg.name);
         break;
       case "argument_positional":
-        positionalArgs.push({ position: arg.position ?? 0, value });
+        positional.push({ position: arg.position ?? 0, name: arg.name });
         break;
       case "volume":
-        // Skip for non-Docker runtimes.
+        // Handled separately via volumes config.
         break;
     }
   }
 
-  const args = [
-    ...positionalArgs
+  return {
+    requiredEnv,
+    requiredArgs,
+    requiredArgsBool,
+    requiredArgsPositional: positional
       .sort((a, b) => a.position - b.position)
-      .map((a) => a.value)
-      .filter(Boolean),
-    ...namedArgs,
-  ];
-
-  return { envVars, args };
+      .map((a) => a.name),
+  };
 }
 
-// Generate correct mcpd TOML from registry data and form values.
+// Build the package identifier including version: runtime::package@version.
+function buildPackageId(installation: {
+  runtime: string;
+  package: string;
+  version?: string;
+}): string {
+  const base = `${installation.runtime}::${installation.package}`;
+  return installation.version ? `${base}@${installation.version}` : base;
+}
+
+// Generate mcpd TOML matching the ServerEntry struct.
 function generateToml(
   server: RegistryServer,
   runtimeKey: string,
-  argValues: Record<string, string>,
   selectedTools: string[],
 ): string {
   const installation = server.installations[runtimeKey];
   if (!installation) return "# No installation found for this runtime";
 
-  const pkg = `${installation.runtime}::${installation.package}`;
+  const tomlArr = (items: string[]) =>
+    `[${items.map((i) => `"${escapeToml(i)}"`).join(", ")}]`;
 
   let toml = "[[servers]]\n";
-  toml += `name = "${escapeToml(server.id)}"\n`;
-  toml += `package = "${escapeToml(pkg)}"\n`;
+  toml += `  name = "${escapeToml(server.id)}"\n`;
+  toml += `  package = "${escapeToml(buildPackageId(installation))}"\n`;
+  toml += `  tools = ${tomlArr(selectedTools)}\n`;
 
-  if (selectedTools.length > 0 && selectedTools.length < server.tools.length) {
-    toml += `tools = [${selectedTools.map((t) => `"${escapeToml(t)}"`).join(", ")}]\n`;
+  const processed = processArguments(server.arguments);
+
+  if (processed.requiredEnv.length > 0) {
+    toml += `  required_env = ${tomlArr(processed.requiredEnv)}\n`;
   }
-
-  const { envVars, args } = processArguments(server.arguments, argValues);
-
-  if (Object.keys(envVars).length > 0) {
-    const pairs = Object.entries(envVars)
-      .map(([k, v]) => `${k} = "${escapeToml(v)}"`)
-      .join(", ");
-    toml += `env = { ${pairs} }\n`;
+  if (processed.requiredArgs.length > 0) {
+    toml += `  required_args = ${tomlArr(processed.requiredArgs)}\n`;
   }
-
-  if (args.length > 0) {
-    toml += `args = [${args.map((a) => `"${escapeToml(a)}"`).join(", ")}]\n`;
+  if (processed.requiredArgsBool.length > 0) {
+    toml += `  required_args_bool = ${tomlArr(processed.requiredArgsBool)}\n`;
+  }
+  if (processed.requiredArgsPositional.length > 0) {
+    toml += `  required_args_positional = ${tomlArr(processed.requiredArgsPositional)}\n`;
   }
 
   return toml;
@@ -283,20 +298,31 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
   );
   const [selectedRuntime, setSelectedRuntime] = useState<string>("");
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
-  const [argValues, setArgValues] = useState<Record<string, string>>({});
   const [tomlPreview, setTomlPreview] = useState("");
   const [adding, setAdding] = useState(false);
+  const [argValues, setArgValues] = useState<Record<string, string | boolean>>(
+    {},
+  );
+
+  const configCardRef = useRef<HTMLDivElement>(null);
 
   // Registry data: bundled snapshot, overlaid with live search results.
   const [liveServers, setLiveServers] = useState<TaggedServer[]>([]);
   const [loadingLive, setLoadingLive] = useState(false);
 
-  // Merge bundled + client-specific + live data (live wins on ID conflicts).
+  // Merge bundled + client-specific + live data. For duplicate IDs, prefer
+  // mozilla-ai entries over other sources (e.g. mcpm).
   const allServers = useMemo(() => {
     const merged = new Map<string, TaggedServer>();
-    for (const s of BUNDLED_SERVERS) merged.set(s.id, s);
-    for (const s of CLIENT_SERVERS) merged.set(s.id, s);
-    for (const s of liveServers) merged.set(s.id, s);
+    const setIfBetter = (s: TaggedServer) => {
+      const existing = merged.get(s.id);
+      if (!existing || s._source === "mozilla-ai") {
+        merged.set(s.id, s);
+      }
+    };
+    for (const s of BUNDLED_SERVERS) setIfBetter(s);
+    for (const s of CLIENT_SERVERS) setIfBetter(s);
+    for (const s of liveServers) setIfBetter(s);
     return Array.from(merged.values());
   }, [liveServers]);
 
@@ -335,7 +361,12 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
     try {
       const results = await window.electronAPI.searchServers("*");
       if (Array.isArray(results)) {
-        setLiveServers(results.map((s) => ({ ...s, _source: "mozilla-ai" })));
+        setLiveServers(
+          results.map((s: RegistryServer & { source?: string }) => ({
+            ...s,
+            _source: s.source || "unknown",
+          })),
+        );
       }
     } catch {
       // Daemon may not be running; bundled data is sufficient.
@@ -367,12 +398,12 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
   useEffect(() => {
     if (selectedServer && selectedRuntime) {
       setTomlPreview(
-        generateToml(selectedServer, selectedRuntime, argValues, selectedTools),
+        generateToml(selectedServer, selectedRuntime, selectedTools),
       );
     } else {
       setTomlPreview("");
     }
-  }, [selectedServer, selectedRuntime, argValues, selectedTools]);
+  }, [selectedServer, selectedRuntime, selectedTools]);
 
   const getCategoryIcon = (category: string) => {
     const icons: Record<string, React.ReactNode> = {
@@ -390,13 +421,13 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
 
   const selectServer = (server: TaggedServer) => {
     setSelectedServer(server);
+    setArgValues({});
 
     // Pick the recommended or first installation.
     const entries = Object.entries(server.installations);
     if (entries.length === 0) {
       setSelectedRuntime("");
       setSelectedTools(server.tools.map((t) => t.name));
-      setArgValues({});
       return;
     }
     const recommended = entries.find(([, inst]) => inst.recommended);
@@ -406,22 +437,19 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
     // Auto-select all tools.
     setSelectedTools(server.tools.map((t) => t.name));
 
-    // Initialize argument values with examples.
-    const initialArgs: Record<string, string> = {};
-    for (const [key, arg] of Object.entries(server.arguments ?? {})) {
-      initialArgs[key] = arg.example ?? "";
-    }
-    setArgValues(initialArgs);
-
     // Pre-fill form.
     form.setFieldsValue({
       name: server.id,
-      package: `${installation.runtime}::${installation.package}`,
+      package: buildPackageId(installation),
     });
-  };
 
-  const updateArgValue = (key: string, value: string) => {
-    setArgValues((prev) => ({ ...prev, [key]: value }));
+    // Scroll config card into view after render.
+    requestAnimationFrame(() => {
+      configCardRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
   };
 
   const updateFilter = (key: keyof ServerFilters, value: unknown) => {
@@ -430,17 +458,6 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
 
   const clearFilters = () => {
     setFilters(EMPTY_FILTERS);
-  };
-
-  // Validate that all required arguments have values.
-  const validateRequiredArgs = (): string | null => {
-    if (!selectedServer?.arguments) return null;
-    for (const [key, arg] of Object.entries(selectedServer.arguments)) {
-      if (arg.required && !(argValues[key] ?? "").trim()) {
-        return `${arg.name} is required`;
-      }
-    }
-    return null;
   };
 
   const handleAdd = async () => {
@@ -460,44 +477,78 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
         await window.electronAPI.addServer(serverConfig);
         message.success(`Server ${values.name} added successfully`);
       } else {
-        // Validate required arguments before submitting.
-        const validationError = validateRequiredArgs();
-        if (validationError) {
-          message.error(validationError);
-          return;
-        }
-
-        // Browse mode: build config from registry data + argument values.
+        // Browse mode: build config from registry data matching mcpd ServerEntry.
         const installation = selectedServer!.installations[selectedRuntime];
         if (!installation) {
           message.error("No installation found for selected runtime");
           return;
         }
-        const pkg = `${installation.runtime}::${installation.package}`;
 
-        const { envVars, args } = processArguments(
-          selectedServer!.arguments,
-          argValues,
-        );
+        const processed = processArguments(selectedServer!.arguments);
 
         const serverConfig: Record<string, unknown> = {
           name: selectedServer!.id,
-          package: pkg,
+          package: buildPackageId(installation),
+          tools: selectedTools,
         };
-        if (
-          selectedTools.length > 0 &&
-          selectedTools.length < selectedServer!.tools.length
-        ) {
-          serverConfig.tools = selectedTools;
+        if (processed.requiredEnv.length > 0) {
+          serverConfig.required_env = processed.requiredEnv;
         }
-        if (Object.keys(envVars).length > 0) {
-          serverConfig.env = envVars;
+        if (processed.requiredArgs.length > 0) {
+          serverConfig.required_args = processed.requiredArgs;
         }
-        if (args.length > 0) {
-          serverConfig.args = args;
+        if (processed.requiredArgsBool.length > 0) {
+          serverConfig.required_args_bool = processed.requiredArgsBool;
+        }
+        if (processed.requiredArgsPositional.length > 0) {
+          serverConfig.required_args_positional =
+            processed.requiredArgsPositional;
         }
 
         await window.electronAPI.addServer(serverConfig);
+
+        // Save user-entered values to secrets.dev.toml if any were provided.
+        // Non-fatal: server config is already saved, so warn instead of failing.
+        if (selectedServer!.arguments && Object.keys(argValues).length > 0) {
+          try {
+            const env: Record<string, string> = {};
+            const args: string[] = [];
+
+            for (const [, arg] of Object.entries(selectedServer!.arguments)) {
+              const value = argValues[arg.name];
+              if (value === undefined || value === "") continue;
+
+              switch (arg.type) {
+                case "environment":
+                  env[arg.name] = value as string;
+                  break;
+                case "argument":
+                  args.push(`--${arg.name}=${value}`);
+                  break;
+                case "argument_bool":
+                  if (value) args.push(`--${arg.name}`);
+                  break;
+                case "argument_positional":
+                  args.push(value as string);
+                  break;
+              }
+            }
+
+            if (Object.keys(env).length > 0 || args.length > 0) {
+              await window.electronAPI.saveServerSecrets(
+                selectedServer!.id,
+                env,
+                args,
+              );
+            }
+          } catch (err) {
+            console.error("Failed to save secrets:", err);
+            message.warning(
+              "Server added, but failed to save secrets. You can configure them manually in ~/.config/mcpd/secrets.dev.toml",
+            );
+          }
+        }
+
         message.success(
           `Server ${selectedServer!.displayName ?? selectedServer!.name} added successfully`,
         );
@@ -513,77 +564,56 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
     }
   };
 
+  const updateArgValue = (name: string, value: string | boolean) => {
+    setArgValues((prev) => ({ ...prev, [name]: value }));
+  };
+
   const renderArgumentField = (key: string, arg: RegistryArgument) => {
-    if (arg.type === "argument_bool") {
-      return (
-        <Form.Item
-          key={key}
-          label={
-            <Space>
-              {arg.name}
-              {arg.required && <Tag color="red">Required</Tag>}
-              <Tag>{arg.type}</Tag>
-            </Space>
-          }
-          help={arg.description}
-        >
-          <Switch
-            checked={argValues[key] === "true"}
-            onChange={(checked) => updateArgValue(key, checked ? "true" : "")}
-          />
-        </Form.Item>
-      );
-    }
+    const typeColor =
+      arg.type === "environment"
+        ? "orange"
+        : arg.type === "argument_bool"
+          ? "cyan"
+          : "default";
 
-    if (arg.type === "environment") {
-      return (
-        <Form.Item
-          key={key}
-          label={
-            <Space>
-              {arg.name}
-              {arg.required && <Tag color="red">Required</Tag>}
-              <Tag color="orange">env</Tag>
-            </Space>
-          }
-          help={arg.description}
-        >
-          <Input.Password
-            value={argValues[key] ?? ""}
-            onChange={(e) => updateArgValue(key, e.target.value)}
-            placeholder={
-              arg.example ? `e.g., ${arg.example}` : `Enter ${arg.name}`
-            }
-            status={
-              arg.required && !(argValues[key] ?? "").trim() ? "error" : ""
-            }
-          />
-        </Form.Item>
-      );
-    }
-
-    // argument, argument_positional, volume.
     return (
-      <Form.Item
-        key={key}
-        label={
+      <div key={key} style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 4 }}>
           <Space>
-            {arg.name}
+            <Text strong>{arg.name}</Text>
             {arg.required && <Tag color="red">Required</Tag>}
-            <Tag>{arg.type}</Tag>
+            <Tag color={typeColor}>{arg.type}</Tag>
           </Space>
-        }
-        help={arg.description}
-      >
-        <Input
-          value={argValues[key] ?? ""}
-          onChange={(e) => updateArgValue(key, e.target.value)}
-          placeholder={
-            arg.example ? `e.g., ${arg.example}` : `Enter value for ${arg.name}`
-          }
-          status={arg.required && !(argValues[key] ?? "").trim() ? "error" : ""}
-        />
-      </Form.Item>
+        </div>
+        <Text
+          type="secondary"
+          style={{ fontSize: 12, display: "block", marginBottom: 4 }}
+        >
+          {arg.description}
+        </Text>
+        {arg.type === "volume" ? (
+          <Input
+            size="small"
+            disabled
+            placeholder="Volume mounts are configured via Docker"
+            value={arg.path || ""}
+          />
+        ) : arg.type === "argument_bool" ? (
+          <Switch
+            checked={!!argValues[arg.name]}
+            onChange={(checked) => updateArgValue(arg.name, checked)}
+            size="small"
+          />
+        ) : (
+          <Input
+            size="small"
+            placeholder={arg.example || `Enter ${arg.name}`}
+            value={(argValues[arg.name] as string) || ""}
+            onChange={(e) => updateArgValue(arg.name, e.target.value)}
+            type={arg.type === "environment" ? "password" : "text"}
+          />
+        )}
+      </div>
     );
   };
 
@@ -619,32 +649,57 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
           <div>
             <Paragraph
               ellipsis={{ rows: 2 }}
-              style={{ marginBottom: 8, fontSize: 13 }}
+              style={{ marginBottom: 4, fontSize: 13 }}
             >
               {server.description}
             </Paragraph>
-            <Space wrap size="small">
-              {server.tools.slice(0, 4).map((tool) => (
-                <Tag key={tool.name} color="geekblue" style={{ fontSize: 11 }}>
-                  {tool.name}
-                </Tag>
-              ))}
-              {server.tools.length > 4 && (
-                <Tag style={{ fontSize: 11 }}>
-                  +{server.tools.length - 4} more
-                </Tag>
+            {server.tools.length > 0 && (
+              <div style={{ marginBottom: 4 }}>
+                <Space wrap size={[4, 4]}>
+                  {server.tools.map((tool) => (
+                    <Tag
+                      key={tool.name}
+                      color="geekblue"
+                      style={{ fontSize: 11, margin: 0 }}
+                    >
+                      {tool.name}
+                    </Tag>
+                  ))}
+                </Space>
+              </div>
+            )}
+            <Space wrap size={[4, 4]}>
+              {Object.entries(server.installations).flatMap(
+                ([instKey, inst]) => {
+                  const tags = [
+                    <Tag
+                      key={instKey}
+                      color="green"
+                      style={{ fontSize: 11, margin: 0 }}
+                    >
+                      {inst.runtime}
+                    </Tag>,
+                  ];
+                  if (inst.version) {
+                    tags.push(
+                      <Tag
+                        key={`ver-${instKey}`}
+                        color="blue"
+                        style={{ fontSize: 11, margin: 0 }}
+                      >
+                        v{inst.version}
+                      </Tag>,
+                    );
+                  }
+                  return tags;
+                },
               )}
-              {Object.values(server.installations).map((inst) => (
-                <Tag key={inst.runtime} color="green" style={{ fontSize: 11 }}>
-                  {inst.runtime}
-                </Tag>
-              ))}
               {isValidLicense(server.license) && (
-                <Tag color="purple" style={{ fontSize: 11 }}>
+                <Tag color="purple" style={{ fontSize: 11, margin: 0 }}>
                   {server.license}
                 </Tag>
               )}
-              <Tag color="cyan" style={{ fontSize: 11 }}>
+              <Tag color="cyan" style={{ fontSize: 11, margin: 0 }}>
                 {server._source}
               </Tag>
             </Space>
@@ -844,23 +899,37 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
       )}
 
       {selectedServer && (
-        <Card title="Server Configuration" style={{ marginTop: 16 }}>
+        <Card
+          ref={configCardRef}
+          title="Server Configuration"
+          style={{ marginTop: 16 }}
+        >
           <Form form={form} layout="vertical">
             <Form.Item name="name" label="Server Name">
               <Input disabled />
             </Form.Item>
 
-            <Form.Item name="package" label="Package">
+            <Form.Item
+              name="package"
+              label={
+                <Space>
+                  Package
+                  {selectedRuntime &&
+                    selectedServer.installations[selectedRuntime]?.version && (
+                      <Tag color="blue">
+                        v{selectedServer.installations[selectedRuntime].version}
+                      </Tag>
+                    )}
+                </Space>
+              }
+            >
               {Object.keys(selectedServer.installations).length > 1 ? (
                 <Select
                   value={selectedRuntime}
                   onChange={(value) => {
                     setSelectedRuntime(value);
                     const inst = selectedServer.installations[value];
-                    form.setFieldValue(
-                      "package",
-                      `${inst.runtime}::${inst.package}`,
-                    );
+                    form.setFieldValue("package", buildPackageId(inst));
                   }}
                 >
                   {Object.entries(selectedServer.installations).map(
@@ -900,7 +969,14 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
             {selectedServer.arguments &&
               Object.keys(selectedServer.arguments).length > 0 && (
                 <>
-                  <Divider orientation="left">Arguments</Divider>
+                  <Divider orientation="left">Configuration Values</Divider>
+                  <Text
+                    type="secondary"
+                    style={{ display: "block", marginBottom: 12, fontSize: 12 }}
+                  >
+                    These values will be saved to your secrets file
+                    (~/.config/mcpd/secrets.dev.toml).
+                  </Text>
                   {Object.entries(selectedServer.arguments).map(([key, arg]) =>
                     renderArgumentField(key, arg),
                   )}

--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -17,12 +17,21 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(false);
   const [totalTools, setTotalTools] = useState(0);
+  const [mcpdVersion, setMcpdVersion] = useState<string>("");
 
   useEffect(() => {
     if (daemonStatus.running) {
       loadServers();
+      if (!mcpdVersion) {
+        window.electronAPI
+          .getDaemonVersion()
+          .then(setMcpdVersion)
+          .catch(console.error);
+      }
+    } else {
+      setMcpdVersion("");
     }
-  }, [daemonStatus]);
+  }, [daemonStatus.running]);
 
   const loadServers = async () => {
     setLoading(true);
@@ -76,6 +85,19 @@ const Dashboard: React.FC<DashboardProps> = ({ daemonStatus }) => {
                 ) : (
                   <CloseCircleOutlined />
                 )
+              }
+              suffix={
+                mcpdVersion && mcpdVersion !== "unknown" ? (
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: "rgba(0,0,0,0.45)",
+                      fontWeight: "normal",
+                    }}
+                  >
+                    ({mcpdVersion})
+                  </span>
+                ) : null
               }
             />
           </Card>

--- a/src/renderer/components/ServerManager.tsx
+++ b/src/renderer/components/ServerManager.tsx
@@ -1,17 +1,58 @@
-import React, { useState, useEffect } from "react";
-import { Card, Table, Button, Tag, Space, message, Popconfirm } from "antd";
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  Card,
+  Table,
+  Button,
+  Tag,
+  Space,
+  Typography,
+  message,
+  Popconfirm,
+} from "antd";
 import {
   PlusOutlined,
   DeleteOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
-import { MCPServer } from "@shared/types";
+import { MCPServer, RegistryData } from "@shared/types";
 import AddServerModal from "./AddServerModal";
+
+import bundledRegistry from "../data/registry.json";
+import clientServers from "../data/client-servers.json";
+
+const { Text } = Typography;
+
+// Build a lookup from server name/id to its recommended installation version.
+function buildVersionMap(
+  ...registries: RegistryData[]
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  // Earlier registries take precedence (bundled mozilla-ai wins over client extras).
+  for (const registry of registries) {
+    for (const [id, server] of Object.entries(registry)) {
+      if (map[id]) continue;
+      const installations = Object.values(server.installations);
+      const recommended = installations.find((i) => i.recommended);
+      const version = (recommended ?? installations[0])?.version;
+      if (version) map[id] = version;
+    }
+  }
+  return map;
+}
 
 const ServerManager: React.FC = () => {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(false);
   const [addModalVisible, setAddModalVisible] = useState(false);
+
+  const versionMap = useMemo(
+    () =>
+      buildVersionMap(
+        bundledRegistry as RegistryData,
+        clientServers as RegistryData,
+      ),
+    [],
+  );
 
   useEffect(() => {
     loadServers();
@@ -73,6 +114,20 @@ const ServerManager: React.FC = () => {
       dataIndex: "package",
       key: "package",
       render: (text: string) => text || "N/A",
+    },
+    {
+      title: "Version",
+      // Looks up by server name which matches the registry ID set during browse-mode add.
+      dataIndex: "name",
+      key: "version",
+      render: (name: string) => {
+        const version = versionMap[name];
+        return version ? (
+          <Tag color="blue">v{version}</Tag>
+        ) : (
+          <Text type="secondary">—</Text>
+        );
+      },
     },
     {
       title: "Status",

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -23,8 +23,10 @@ export interface ConfigEntry {
   name: string;
   package: string;
   tools?: string[];
-  env?: Record<string, string>;
-  args?: string[];
+  required_env?: string[];
+  required_args?: string[];
+  required_args_bool?: string[];
+  required_args_positional?: string[];
 }
 
 export interface IpcChannels {
@@ -33,6 +35,8 @@ export interface IpcChannels {
   "daemon:stop": () => Promise<void>;
   "daemon:status": () => Promise<DaemonStatus>;
   "daemon:logs": () => Promise<string[]>;
+  "daemon:version": () => Promise<string>;
+  "app:version": () => Promise<string>;
 
   // Server management
   "servers:list": () => Promise<MCPServer[]>;
@@ -47,6 +51,14 @@ export interface IpcChannels {
   "config:load": () => Promise<ConfigEntry[]>;
   "config:save": (config: ConfigEntry[]) => Promise<void>;
   "config:export": () => Promise<string>;
+
+  // Secrets management
+  "secrets:save-server": (
+    serverName: string,
+    env: Record<string, string>,
+    args: string[],
+  ) => Promise<void>;
+  "secrets:path": () => Promise<string>;
 }
 
 export interface LogEntry {


### PR DESCRIPTION
## Summary

- Display **app version** in the sidebar footer, **mcpd daemon version** on the Dashboard status card
- Show **registry installation version** per server in the Add Server modal browse list and Servers table
- **Align TOML config with mcpd's ServerEntry struct**: package includes version (e.g. `npx::pkg@0.3.0`), uses `required_env`, `required_args`, `required_args_bool`, `required_args_positional`
- Prefer **mozilla-ai** registry entries over mcpm on ID clashes
- Use actual `source` field from live search results for source tagging
- Show all tool tags without truncation
- Scroll config card into view when a server is selected

## Test plan

- [ ] Verify app version appears in sidebar footer (hidden when collapsed)
- [ ] Verify mcpd version shows next to "Running" on Dashboard
- [ ] Verify server versions appear in Add Server modal and Servers table
- [ ] Select Airtable and verify TOML preview shows `package = "npx::@felores/airtable-mcp-server@0.3.0"` with `required_env = ["AIRTABLE_API_KEY"]`
- [ ] Verify mozilla-ai entries win over mcpm duplicates (e.g. Elasticsearch shows version)
- [ ] Verify clicking a server scrolls the config card into view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App and daemon versions displayed in the UI (sidebar and beside daemon status).
  * Persist per‑server secrets and provide the secrets file path.
  * Server list includes an installation version column.

* **Improvements**
  * Add-server flow and TOML previews reworked to standardise env/args/positional/flags.
  * UI refinements: spacing, tags, list layouts and smoother scrolling.
  * Daemon version is cached for faster display; secrets saved automatically when adding from registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->