### PR TITLE
feat: show configured servers when daemon is stopped

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -76,20 +76,19 @@ export function setupIPC(mcpdManager: McpdManager) {
   ipcMain.handle("servers:list", async () => {
     const serverNames = await mcpdManager.getServers();
     const configuredServers = await mcpdManager.getConfiguredServers();
-    const servers = [];
+    const runningSet = new Set(serverNames);
 
-    for (const name of serverNames) {
-      const configServer = configuredServers.find((s) => s.name === name);
-      servers.push({
-        name,
-        package: configServer?.package || "",
-        tools: [],
-        status: "running" as const,
-        health: "healthy" as const,
-      });
-    }
-
-    return servers;
+    return configuredServers.map((cs) => ({
+      name: cs.name,
+      package: cs.package || "",
+      tools: [],
+      status: runningSet.has(cs.name)
+        ? ("running" as const)
+        : ("stopped" as const),
+      health: runningSet.has(cs.name)
+        ? ("healthy" as const)
+        : ("unknown" as const),
+    }));
   });
 
   ipcMain.handle("servers:add", async (_, server: any) => {
@@ -153,6 +152,66 @@ export function setupIPC(mcpdManager: McpdManager) {
 
   ipcMain.handle("secrets:path", () => {
     return mcpdManager.getSecretsPath();
+  });
+
+  ipcMain.handle("config:path", () => {
+    return mcpdManager.getConfigPath();
+  });
+
+  // Add server from registry using mcpd CLI.
+  ipcMain.handle(
+    "servers:add-registry",
+    async (
+      _,
+      name: string,
+      runtime: string,
+      version: string,
+      tools: string[],
+    ) => {
+      return await mcpdManager.addServerFromRegistry(
+        name,
+        runtime,
+        version,
+        tools,
+      );
+    },
+  );
+
+  // Set environment variables for a server using mcpd CLI.
+  ipcMain.handle(
+    "secrets:set-env",
+    async (_, name: string, env: Record<string, string>) => {
+      return await mcpdManager.setServerEnv(name, env);
+    },
+  );
+
+  // Set arguments for a server using mcpd CLI.
+  ipcMain.handle(
+    "secrets:set-args",
+    async (
+      _,
+      name: string,
+      positionalArgs: string[],
+      cliArgs: string[],
+      boolArgs: string[],
+    ) => {
+      return await mcpdManager.setServerArgs(
+        name,
+        positionalArgs,
+        cliArgs,
+        boolArgs,
+      );
+    },
+  );
+
+  // Load raw secrets file content.
+  ipcMain.handle("secrets:load", async () => {
+    return await mcpdManager.loadSecretsContent();
+  });
+
+  // Save raw secrets file content.
+  ipcMain.handle("secrets:save", async (_, content: string) => {
+    return await mcpdManager.saveSecretsContent(content);
   });
 
   // Connect functionality - simplified one-click setup using mcpd-proxy.

--- a/src/main/mcpd-manager.ts
+++ b/src/main/mcpd-manager.ts
@@ -585,16 +585,7 @@ export class McpdManager {
     );
 
     // Restart daemon to pick up new configuration.
-    console.log(
-      `[${this.constructor.name}] Restarting daemon to load new server...`,
-    );
-    const wasRunning = await this.getStatus();
-    if (wasRunning.running) {
-      await this.stopDaemon();
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      await this.startDaemon();
-      console.log(`[${this.constructor.name}] Daemon restarted successfully`);
-    }
+    await this.restartDaemonIfRunning();
   }
 
   async removeServerFromConfig(name: string): Promise<void> {
@@ -619,16 +610,150 @@ export class McpdManager {
     fs.writeFileSync(this.configPath, tomlString);
 
     // Restart daemon to pick up configuration changes.
-    console.log(
-      `[${this.constructor.name}] Restarting daemon to reload configuration...`,
-    );
-    const wasRunning = await this.getStatus();
-    if (wasRunning.running) {
+    await this.restartDaemonIfRunning();
+  }
+
+  // Run an mcpd CLI subcommand and return stdout. Rejects on non-zero exit.
+  private runMcpdCommand(args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(this.mcpdPath, args, {
+        cwd: app.getPath("userData"),
+        env: {
+          ...process.env,
+          PATH: this.buildFullPath(),
+        },
+      });
+
+      let stdout = "";
+      let stderr = "";
+      proc.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
+      proc.stderr?.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on("error", (err) => {
+        reject(new Error(`Failed to run mcpd: ${err.message}`));
+      });
+
+      proc.on("exit", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(
+            new Error(
+              `mcpd ${args[0]} failed (exit ${code}): ${stderr || stdout}`,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  // Stop and restart the daemon if it is currently running.
+  private async restartDaemonIfRunning(): Promise<void> {
+    console.log(`[${this.constructor.name}] Restarting daemon if running...`);
+    const status = await this.getStatus();
+    if (status.running) {
       await this.stopDaemon();
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await this.startDaemon();
       console.log(`[${this.constructor.name}] Daemon restarted successfully`);
     }
+  }
+
+  // Add a server from the registry using mcpd CLI.
+  async addServerFromRegistry(
+    name: string,
+    runtime: string,
+    version: string,
+    tools: string[],
+  ): Promise<void> {
+    const args = [
+      "add",
+      name,
+      `--runtime=${runtime}`,
+      `--config-file=${this.configPath}`,
+      `--runtime-file=${this.secretsPath}`,
+    ];
+    if (version) {
+      args.push(`--version=${version}`);
+    }
+    for (const tool of tools) {
+      args.push(`--tool=${tool}`);
+    }
+
+    await this.runMcpdCommand(args);
+    await this.restartDaemonIfRunning();
+  }
+
+  // Set environment variables for a server using mcpd CLI.
+  async setServerEnv(name: string, env: Record<string, string>): Promise<void> {
+    const kvPairs = Object.entries(env).map(([k, v]) => `${k}=${v}`);
+    if (kvPairs.length === 0) return;
+
+    const args = [
+      "config",
+      "env",
+      "set",
+      name,
+      `--config-file=${this.configPath}`,
+      `--runtime-file=${this.secretsPath}`,
+      ...kvPairs,
+    ];
+
+    await this.runMcpdCommand(args);
+  }
+
+  // Set arguments for a server using mcpd CLI.
+  async setServerArgs(
+    name: string,
+    positionalArgs: string[],
+    cliArgs: string[],
+    boolArgs: string[],
+  ): Promise<void> {
+    if (
+      positionalArgs.length === 0 &&
+      cliArgs.length === 0 &&
+      boolArgs.length === 0
+    ) {
+      return;
+    }
+
+    // Flags must come before the -- separator.
+    const args = [
+      "config",
+      "args",
+      "set",
+      name,
+      `--config-file=${this.configPath}`,
+      `--runtime-file=${this.secretsPath}`,
+      "--",
+      ...positionalArgs,
+      ...cliArgs,
+      ...boolArgs,
+    ];
+
+    await this.runMcpdCommand(args);
+  }
+
+  // Load the raw content of the secrets file.
+  async loadSecretsContent(): Promise<{ content: string }> {
+    if (!fs.existsSync(this.secretsPath)) {
+      return { content: "" };
+    }
+    const content = fs.readFileSync(this.secretsPath, "utf-8");
+    return { content };
+  }
+
+  // Overwrite the secrets file with the provided content.
+  async saveSecretsContent(content: string): Promise<void> {
+    const secretsDir = path.dirname(this.secretsPath);
+    if (!fs.existsSync(secretsDir)) {
+      fs.mkdirSync(secretsDir, { recursive: true });
+    }
+    fs.writeFileSync(this.secretsPath, content);
   }
 
   async getMcpdVersion(): Promise<string> {
@@ -722,6 +847,10 @@ export class McpdManager {
       `[${this.constructor.name}] Server secrets saved to:`,
       this.secretsPath,
     );
+  }
+
+  getConfigPath(): string {
+    return this.configPath;
   }
 
   getSecretsPath(): string {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -55,6 +55,49 @@ try {
       args: string[],
     ) => ipcRenderer.invoke("secrets:save-server", serverName, env, args),
     getSecretsPath: () => ipcRenderer.invoke("secrets:path") as Promise<string>,
+    getConfigPath: () => ipcRenderer.invoke("config:path") as Promise<string>,
+
+    // Add server from registry using mcpd CLI.
+    addServerFromRegistry: (
+      name: string,
+      runtime: string,
+      version: string,
+      tools: string[],
+    ) =>
+      ipcRenderer.invoke(
+        "servers:add-registry",
+        name,
+        runtime,
+        version,
+        tools,
+      ) as Promise<void>,
+
+    // Set environment variables for a server via mcpd CLI.
+    setServerEnv: (name: string, env: Record<string, string>) =>
+      ipcRenderer.invoke("secrets:set-env", name, env) as Promise<void>,
+
+    // Set arguments for a server via mcpd CLI.
+    setServerArgs: (
+      name: string,
+      positionalArgs: string[],
+      cliArgs: string[],
+      boolArgs: string[],
+    ) =>
+      ipcRenderer.invoke(
+        "secrets:set-args",
+        name,
+        positionalArgs,
+        cliArgs,
+        boolArgs,
+      ) as Promise<void>,
+
+    // Load raw secrets file content.
+    loadSecretsContent: () =>
+      ipcRenderer.invoke("secrets:load") as Promise<{ content: string }>,
+
+    // Save raw secrets file content.
+    saveSecretsContent: (content: string) =>
+      ipcRenderer.invoke("secrets:save", content) as Promise<void>,
 
     // Tool execution
     callTool: (server: string, tool: string, args: any) =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -52,6 +52,25 @@ declare global {
         args: string[],
       ) => Promise<void>;
       getSecretsPath: () => Promise<string>;
+      getConfigPath: () => Promise<string>;
+      addServerFromRegistry: (
+        name: string,
+        runtime: string,
+        version: string,
+        tools: string[],
+      ) => Promise<void>;
+      setServerEnv: (
+        name: string,
+        env: Record<string, string>,
+      ) => Promise<void>;
+      setServerArgs: (
+        name: string,
+        positionalArgs: string[],
+        cliArgs: string[],
+        boolArgs: string[],
+      ) => Promise<void>;
+      loadSecretsContent: () => Promise<{ content: string }>;
+      saveSecretsContent: (content: string) => Promise<void>;
       callTool: (server: string, tool: string, args: any) => Promise<any>;
       loadConfig: () => Promise<any>;
       saveConfig: (content: string) => Promise<void>;

--- a/src/renderer/components/AddServerModal.tsx
+++ b/src/renderer/components/AddServerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Modal,
   Form,
@@ -14,7 +14,6 @@ import {
   List,
   Typography,
   message,
-  Card,
   Row,
   Col,
   Collapse,
@@ -32,8 +31,8 @@ import {
   LoadingOutlined,
   SafetyCertificateOutlined,
   FilterOutlined,
+  ArrowLeftOutlined,
 } from "@ant-design/icons";
-import MonacoEditor from "@monaco-editor/react";
 import { RegistryServer, RegistryArgument, RegistryData } from "@shared/types";
 import bundledRegistry from "../data/registry.json";
 import clientServers from "../data/client-servers.json";
@@ -63,6 +62,98 @@ interface ServerFilters {
 }
 
 const EMPTY_FILTERS: ServerFilters = { tags: [] };
+
+// Simple TOML syntax highlighting for preview blocks.
+const TOML_HIGHLIGHT_COLORS = {
+  comment: "#6a9955",
+  section: "#569cd6",
+  key: "#9cdcfe",
+  string: "#ce9178",
+  keyword: "#569cd6",
+  number: "#b5cea8",
+  delimiter: "#d4d4d4",
+};
+
+// Tokenize a single line into highlighted spans.
+function highlightTomlLine(line: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let remaining = line;
+  let idx = 0;
+
+  const push = (text: string, color?: string) => {
+    if (!text) return;
+    nodes.push(
+      color ? (
+        <span key={idx++} style={{ color }}>
+          {text}
+        </span>
+      ) : (
+        <span key={idx++}>{text}</span>
+      ),
+    );
+  };
+
+  // Comment line.
+  if (/^\s*#/.test(remaining)) {
+    push(remaining, TOML_HIGHLIGHT_COLORS.comment);
+    return nodes;
+  }
+
+  // Section header: [[...]] or [...].
+  const sectionMatch = remaining.match(/^(\s*)(\[\[?.+?\]?\])(.*)$/);
+  if (sectionMatch) {
+    push(sectionMatch[1]);
+    push(sectionMatch[2], TOML_HIGHLIGHT_COLORS.section);
+    push(sectionMatch[3]);
+    return nodes;
+  }
+
+  // Key = value line.
+  const kvMatch = remaining.match(/^(\s*)([\w.-]+)(\s*=\s*)(.*)/);
+  if (kvMatch) {
+    push(kvMatch[1]);
+    push(kvMatch[2], TOML_HIGHLIGHT_COLORS.key);
+    push(kvMatch[3], TOML_HIGHLIGHT_COLORS.delimiter);
+    remaining = kvMatch[4];
+
+    // Highlight the value portion with simple token matching.
+    const valTokens =
+      remaining.match(
+        /("(?:[^"\\]|\\.)*"|'[^']*'|true|false|[+-]?\d+(?:\.\d+)?|\[|\]|,|\s+|[^\s,[\]"']+)/g,
+      ) || [];
+    for (const token of valTokens) {
+      if (/^["']/.test(token)) {
+        push(token, TOML_HIGHLIGHT_COLORS.string);
+      } else if (/^(true|false)$/.test(token)) {
+        push(token, TOML_HIGHLIGHT_COLORS.keyword);
+      } else if (/^[+-]?\d+(\.\d+)?$/.test(token)) {
+        push(token, TOML_HIGHLIGHT_COLORS.number);
+      } else {
+        push(token);
+      }
+    }
+    return nodes;
+  }
+
+  // Fallback: unhighlighted.
+  push(remaining);
+  return nodes;
+}
+
+// Render TOML content with syntax highlighting.
+function HighlightedToml({ content }: { content: string }) {
+  const lines = content.split("\n");
+  return (
+    <>
+      {lines.map((line, i) => (
+        <React.Fragment key={i}>
+          {highlightTomlLine(line)}
+          {i < lines.length - 1 && "\n"}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
 
 // Escape a string for use in a TOML quoted value.
 function escapeToml(value: string): string {
@@ -198,8 +289,10 @@ interface ProcessedArgs {
 }
 
 // Shared argument processing: maps registry arguments to mcpd config fields.
+// When argValues is provided, optional args with user-entered values are included.
 function processArguments(
   serverArgs: Record<string, RegistryArgument> | undefined,
+  argValues?: Record<string, string | boolean>,
 ): ProcessedArgs {
   const requiredEnv: string[] = [];
   const requiredArgs: string[] = [];
@@ -207,7 +300,10 @@ function processArguments(
   const positional: { position: number; name: string }[] = [];
 
   for (const [, arg] of Object.entries(serverArgs ?? {})) {
-    if (!arg.required) continue;
+    const userValue = argValues?.[arg.name];
+    const hasValue =
+      userValue !== undefined && userValue !== "" && userValue !== false;
+    if (!arg.required && !hasValue) continue;
 
     switch (arg.type) {
       case "environment":
@@ -248,11 +344,78 @@ function buildPackageId(installation: {
   return installation.version ? `${base}@${installation.version}` : base;
 }
 
+// Build the secrets TOML preview showing what will be written to secrets.dev.toml.
+// Environment values are masked unless their field is toggled visible.
+function buildSecretsPreview(
+  serverId: string,
+  serverArgs: Record<string, RegistryArgument> | undefined,
+  argValues: Record<string, string | boolean>,
+  visibleFields: Set<string>,
+): string {
+  if (!serverArgs || Object.keys(argValues).length === 0) return "";
+
+  const envLines: string[] = [];
+  const positionalArgs: { position: number; value: string }[] = [];
+  const cliArgs: string[] = [];
+
+  for (const [, arg] of Object.entries(serverArgs)) {
+    const value = argValues[arg.name];
+    if (value === undefined || value === "" || value === false) continue;
+
+    switch (arg.type) {
+      case "environment": {
+        const display = visibleFields.has(arg.name)
+          ? `"${escapeToml(value as string)}"`
+          : '"********"';
+        envLines.push(`  ${arg.name} = ${display}`);
+        break;
+      }
+      case "argument":
+        cliArgs.push(`${arg.name}=${value}`);
+        break;
+      case "argument_bool":
+        if (value) cliArgs.push(arg.name);
+        break;
+      case "argument_positional":
+        positionalArgs.push({
+          position: arg.position ?? 0,
+          value: value as string,
+        });
+        break;
+    }
+  }
+
+  const sortedPositional = positionalArgs
+    .sort((a, b) => a.position - b.position)
+    .map((a) => a.value);
+  const allArgs = [...sortedPositional, ...cliArgs];
+
+  if (envLines.length === 0 && allArgs.length === 0) return "";
+
+  let preview = "";
+  if (allArgs.length > 0) {
+    const argsArr = allArgs.map((a) => `"${escapeToml(a)}"`).join(", ");
+    preview += `[servers.${serverId}]\n`;
+    preview += `  args = [${argsArr}]\n`;
+  }
+  if (envLines.length > 0) {
+    if (allArgs.length === 0) {
+      // Still need the server section header for env.
+      preview += `[servers.${serverId}]\n`;
+    }
+    preview += `\n[servers.${serverId}.env]\n`;
+    preview += envLines.join("\n") + "\n";
+  }
+
+  return preview;
+}
+
 // Generate mcpd TOML matching the ServerEntry struct.
 function generateToml(
   server: RegistryServer,
   runtimeKey: string,
   selectedTools: string[],
+  argValues?: Record<string, string | boolean>,
 ): string {
   const installation = server.installations[runtimeKey];
   if (!installation) return "# No installation found for this runtime";
@@ -265,7 +428,7 @@ function generateToml(
   toml += `  package = "${escapeToml(buildPackageId(installation))}"\n`;
   toml += `  tools = ${tomlArr(selectedTools)}\n`;
 
-  const processed = processArguments(server.arguments);
+  const processed = processArguments(server.arguments, argValues);
 
   if (processed.requiredEnv.length > 0) {
     toml += `  required_env = ${tomlArr(processed.requiredEnv)}\n`;
@@ -298,14 +461,17 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
   );
   const [selectedRuntime, setSelectedRuntime] = useState<string>("");
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
-  const [tomlPreview, setTomlPreview] = useState("");
+  const [configPreview, setConfigPreview] = useState("");
+  const [secretsPreview, setSecretsPreview] = useState("");
+  const [configPath, setConfigPath] = useState("");
+  const [secretsPath, setSecretsPath] = useState("");
   const [adding, setAdding] = useState(false);
   const [argValues, setArgValues] = useState<Record<string, string | boolean>>(
     {},
   );
-
-  const configCardRef = useRef<HTMLDivElement>(null);
-
+  const [visibleEnvFields, setVisibleEnvFields] = useState<Set<string>>(
+    new Set(),
+  );
   // Registry data: bundled snapshot, overlaid with live search results.
   const [liveServers, setLiveServers] = useState<TaggedServer[]>([]);
   const [loadingLive, setLoadingLive] = useState(false);
@@ -375,10 +541,18 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
     }
   };
 
-  // Fetch live registry from daemon when modal opens.
+  // Fetch live registry and file paths when modal opens.
   useEffect(() => {
     if (visible) {
       fetchLiveRegistry();
+      window.electronAPI
+        .getConfigPath()
+        .then(setConfigPath)
+        .catch(console.error);
+      window.electronAPI
+        .getSecretsPath()
+        .then(setSecretsPath)
+        .catch(console.error);
     } else {
       // Reset all state when modal closes.
       form.resetFields();
@@ -390,20 +564,37 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
       setSearchQuery("");
       setFilters(EMPTY_FILTERS);
       setShowFilters(false);
-      setTomlPreview("");
+      setConfigPreview("");
+      setSecretsPreview("");
+      setVisibleEnvFields(new Set());
     }
   }, [visible, form]);
 
-  // Regenerate TOML preview when relevant state changes.
+  // Regenerate TOML previews when relevant state changes.
   useEffect(() => {
     if (selectedServer && selectedRuntime) {
-      setTomlPreview(
-        generateToml(selectedServer, selectedRuntime, selectedTools),
+      setConfigPreview(
+        generateToml(selectedServer, selectedRuntime, selectedTools, argValues),
+      );
+      setSecretsPreview(
+        buildSecretsPreview(
+          selectedServer.id,
+          selectedServer.arguments,
+          argValues,
+          visibleEnvFields,
+        ),
       );
     } else {
-      setTomlPreview("");
+      setConfigPreview("");
+      setSecretsPreview("");
     }
-  }, [selectedServer, selectedRuntime, selectedTools]);
+  }, [
+    selectedServer,
+    selectedRuntime,
+    selectedTools,
+    argValues,
+    visibleEnvFields,
+  ]);
 
   const getCategoryIcon = (category: string) => {
     const icons: Record<string, React.ReactNode> = {
@@ -422,6 +613,7 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
   const selectServer = (server: TaggedServer) => {
     setSelectedServer(server);
     setArgValues({});
+    setVisibleEnvFields(new Set());
 
     // Pick the recommended or first installation.
     const entries = Object.entries(server.installations);
@@ -441,14 +633,6 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
     form.setFieldsValue({
       name: server.id,
       package: buildPackageId(installation),
-    });
-
-    // Scroll config card into view after render.
-    requestAnimationFrame(() => {
-      configCardRef.current?.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
     });
   };
 
@@ -477,75 +661,122 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
         await window.electronAPI.addServer(serverConfig);
         message.success(`Server ${values.name} added successfully`);
       } else {
-        // Browse mode: build config from registry data matching mcpd ServerEntry.
+        // Browse mode: use mcpd CLI to add the server from the registry.
         const installation = selectedServer!.installations[selectedRuntime];
         if (!installation) {
           message.error("No installation found for selected runtime");
           return;
         }
 
-        const processed = processArguments(selectedServer!.arguments);
+        await window.electronAPI.addServerFromRegistry(
+          selectedServer!.id,
+          installation.runtime,
+          installation.version || "",
+          selectedTools,
+        );
 
-        const serverConfig: Record<string, unknown> = {
-          name: selectedServer!.id,
-          package: buildPackageId(installation),
-          tools: selectedTools,
-        };
-        if (processed.requiredEnv.length > 0) {
-          serverConfig.required_env = processed.requiredEnv;
-        }
-        if (processed.requiredArgs.length > 0) {
-          serverConfig.required_args = processed.requiredArgs;
-        }
-        if (processed.requiredArgsBool.length > 0) {
-          serverConfig.required_args_bool = processed.requiredArgsBool;
-        }
-        if (processed.requiredArgsPositional.length > 0) {
-          serverConfig.required_args_positional =
-            processed.requiredArgsPositional;
-        }
-
-        await window.electronAPI.addServer(serverConfig);
-
-        // Save user-entered values to secrets.dev.toml if any were provided.
+        // Save user-entered env/args via mcpd CLI.
         // Non-fatal: server config is already saved, so warn instead of failing.
         if (selectedServer!.arguments && Object.keys(argValues).length > 0) {
           try {
             const env: Record<string, string> = {};
-            const args: string[] = [];
+            const positionalArgs: string[] = [];
+            const cliArgs: string[] = [];
+            const boolArgs: string[] = [];
+            const positionalEntries: { position: number; value: string }[] = [];
 
             for (const [, arg] of Object.entries(selectedServer!.arguments)) {
               const value = argValues[arg.name];
-              if (value === undefined || value === "") continue;
+              if (value === undefined || value === "" || value === false)
+                continue;
 
               switch (arg.type) {
                 case "environment":
                   env[arg.name] = value as string;
                   break;
                 case "argument":
-                  args.push(`--${arg.name}=${value}`);
+                  cliArgs.push(`${arg.name}=${value}`);
                   break;
                 case "argument_bool":
-                  if (value) args.push(`--${arg.name}`);
+                  if (value) boolArgs.push(arg.name);
                   break;
                 case "argument_positional":
-                  args.push(value as string);
+                  positionalEntries.push({
+                    position: arg.position ?? 0,
+                    value: value as string,
+                  });
                   break;
               }
             }
 
-            if (Object.keys(env).length > 0 || args.length > 0) {
-              await window.electronAPI.saveServerSecrets(
+            positionalEntries
+              .sort((a, b) => a.position - b.position)
+              .forEach((a) => positionalArgs.push(a.value));
+
+            if (Object.keys(env).length > 0) {
+              await window.electronAPI.setServerEnv(selectedServer!.id, env);
+            }
+            if (
+              positionalArgs.length > 0 ||
+              cliArgs.length > 0 ||
+              boolArgs.length > 0
+            ) {
+              await window.electronAPI.setServerArgs(
                 selectedServer!.id,
-                env,
-                args,
+                positionalArgs,
+                cliArgs,
+                boolArgs,
               );
             }
-          } catch (err) {
+          } catch (err: any) {
             console.error("Failed to save secrets:", err);
-            message.warning(
-              "Server added, but failed to save secrets. You can configure them manually in ~/.config/mcpd/secrets.dev.toml",
-            );
+            const errorDetail = err?.message || String(err);
+            const serverId = selectedServer!.id;
+            Modal.confirm({
+              title: "Server added with errors",
+              content: (
+                <div>
+                  <p>
+                    The server was added to your config, but saving
+                    environment/argument values failed. You can keep the server
+                    and configure secrets manually, or remove it and try again.
+                  </p>
+                  <pre
+                    style={{
+                      background: "#f5f5f5",
+                      padding: 8,
+                      borderRadius: 4,
+                      fontSize: 12,
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-all",
+                    }}
+                  >
+                    {errorDetail}
+                  </pre>
+                </div>
+              ),
+              okText: "Keep Server",
+              cancelText: "Remove Server",
+              onOk: () => {
+                onSuccess();
+                onClose();
+              },
+              onCancel: async () => {
+                try {
+                  await window.electronAPI.removeServer(serverId);
+                  message.info(`Server ${serverId} removed`);
+                  onSuccess();
+                  onClose();
+                } catch (removeErr: any) {
+                  message.error(
+                    `Failed to remove server: ${removeErr?.message || removeErr}`,
+                  );
+                }
+              },
+            });
+            // Return early so the success toast and modal close are
+            // deferred until the user picks "Keep" or "Remove".
+            return;
           }
         }
 
@@ -604,13 +835,33 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
             onChange={(checked) => updateArgValue(arg.name, checked)}
             size="small"
           />
+        ) : arg.type === "environment" ? (
+          <Input.Password
+            size="small"
+            placeholder={arg.example || `Enter ${arg.name}`}
+            value={(argValues[arg.name] as string) || ""}
+            onChange={(e) => updateArgValue(arg.name, e.target.value)}
+            visibilityToggle={{
+              visible: visibleEnvFields.has(arg.name),
+              onVisibleChange: (v) => {
+                setVisibleEnvFields((prev) => {
+                  const next = new Set(prev);
+                  if (v) {
+                    next.add(arg.name);
+                  } else {
+                    next.delete(arg.name);
+                  }
+                  return next;
+                });
+              },
+            }}
+          />
         ) : (
           <Input
             size="small"
             placeholder={arg.example || `Enter ${arg.name}`}
             value={(argValues[arg.name] as string) || ""}
             onChange={(e) => updateArgValue(arg.name, e.target.value)}
-            type={arg.type === "environment" ? "password" : "text"}
           />
         )}
       </div>
@@ -622,8 +873,6 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
       onClick={() => selectServer(server)}
       style={{
         cursor: "pointer",
-        background:
-          selectedServer?.id === server.id ? "#1890ff20" : "transparent",
         padding: 12,
         borderRadius: 4,
         marginBottom: 8,
@@ -828,82 +1077,127 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
 
   const renderBrowseMode = () => (
     <div>
-      <Space style={{ width: "100%", marginBottom: 8 }} direction="vertical">
-        <Space style={{ width: "100%" }}>
-          <Input.Search
-            placeholder="Search servers by name, description, tool, or tag..."
-            onChange={(e) => setSearchQuery(e.target.value)}
-            value={searchQuery}
-            allowClear
-            style={{ flex: 1 }}
-          />
-          <Button
-            icon={<FilterOutlined />}
-            onClick={() => setShowFilters(!showFilters)}
-            type={activeFilterCount > 0 ? "primary" : "default"}
-            size="middle"
+      {!selectedServer && (
+        <>
+          <Space
+            style={{ width: "100%", marginBottom: 8 }}
+            direction="vertical"
           >
-            Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
-          </Button>
-        </Space>
-        {showFilters && renderFilterBar()}
-        {loadingLive && (
-          <Text type="secondary" style={{ fontSize: 12 }}>
-            <LoadingOutlined /> Loading live registry from daemon...
-          </Text>
-        )}
-        <Text type="secondary" style={{ fontSize: 12 }}>
-          {filteredServers.length} server
-          {filteredServers.length !== 1 ? "s" : ""}
-          {searchQuery || activeFilterCount > 0 ? " matching" : " available"}
-        </Text>
-      </Space>
+            <Space style={{ width: "100%" }}>
+              <Input.Search
+                placeholder="Search servers by name, description, tool, or tag..."
+                onChange={(e) => setSearchQuery(e.target.value)}
+                value={searchQuery}
+                allowClear
+                style={{ flex: 1 }}
+              />
+              <Button
+                icon={<FilterOutlined />}
+                onClick={() => setShowFilters(!showFilters)}
+                type={activeFilterCount > 0 ? "primary" : "default"}
+                size="middle"
+              >
+                Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+              </Button>
+            </Space>
+            {showFilters && renderFilterBar()}
+            {loadingLive && (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                <LoadingOutlined /> Loading live registry from daemon...
+              </Text>
+            )}
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {filteredServers.length} server
+              {filteredServers.length !== 1 ? "s" : ""}
+              {searchQuery || activeFilterCount > 0
+                ? " matching"
+                : " available"}
+            </Text>
+          </Space>
 
-      {filteredServers.length === 0 ? (
-        <Empty
-          description={
-            searchQuery || activeFilterCount > 0
-              ? "No servers match the current filters"
-              : "No servers available"
-          }
-        />
-      ) : (
-        <div style={{ maxHeight: 400, overflow: "auto" }}>
-          {searchQuery || activeFilterCount > 0 ? (
-            <List
-              dataSource={filteredServers}
-              renderItem={renderServerListItem}
+          {filteredServers.length === 0 ? (
+            <Empty
+              description={
+                searchQuery || activeFilterCount > 0
+                  ? "No servers match the current filters"
+                  : "No servers available"
+              }
             />
           ) : (
-            <Collapse defaultActiveKey={Object.keys(serversByCategory)} ghost>
-              {Object.entries(serversByCategory).map(([category, servers]) => (
-                <Collapse.Panel
-                  key={category}
-                  header={
-                    <Space>
-                      {getCategoryIcon(category)}
-                      <Text strong>{category}</Text>
-                      <Tag>{servers.length} servers</Tag>
-                    </Space>
-                  }
+            <div style={{ maxHeight: 400, overflow: "auto" }}>
+              {searchQuery || activeFilterCount > 0 ? (
+                <List
+                  dataSource={filteredServers}
+                  renderItem={renderServerListItem}
+                />
+              ) : (
+                <Collapse
+                  defaultActiveKey={Object.keys(serversByCategory)}
+                  ghost
                 >
-                  <List
-                    dataSource={servers}
-                    renderItem={renderServerListItem}
-                  />
-                </Collapse.Panel>
-              ))}
-            </Collapse>
+                  {Object.entries(serversByCategory).map(
+                    ([category, servers]) => (
+                      <Collapse.Panel
+                        key={category}
+                        header={
+                          <Space>
+                            {getCategoryIcon(category)}
+                            <Text strong>{category}</Text>
+                            <Tag>{servers.length} servers</Tag>
+                          </Space>
+                        }
+                      >
+                        <List
+                          dataSource={servers}
+                          renderItem={renderServerListItem}
+                        />
+                      </Collapse.Panel>
+                    ),
+                  )}
+                </Collapse>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
 
       {selectedServer && (
-        <Card
-          ref={configCardRef}
-          title="Server Configuration"
-          style={{ marginTop: 16 }}
-        >
+        <div>
+          <Button
+            type="text"
+            icon={<ArrowLeftOutlined />}
+            onClick={() => setSelectedServer(null)}
+            style={{ marginBottom: 12, paddingLeft: 0 }}
+          >
+            Back to servers
+          </Button>
+
+          <div style={{ marginBottom: 16 }}>
+            <Space>
+              <Text strong style={{ fontSize: 16 }}>
+                {selectedServer.displayName ?? selectedServer.name}
+              </Text>
+              {selectedServer.isOfficial && (
+                <Tag color="blue" icon={<SafetyCertificateOutlined />}>
+                  Official
+                </Tag>
+              )}
+            </Space>
+            <Paragraph
+              type="secondary"
+              style={{ marginBottom: 4, marginTop: 4 }}
+            >
+              {selectedServer.description}
+            </Paragraph>
+            {selectedServer.tags && selectedServer.tags.length > 0 && (
+              <Space wrap size={[4, 4]}>
+                {selectedServer.tags.map((t) => (
+                  <Tag key={t}>{t}</Tag>
+                ))}
+              </Space>
+            )}
+          </div>
+
           <Form form={form} layout="vertical">
             <Form.Item name="name" label="Server Name">
               <Input disabled />
@@ -972,7 +1266,11 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
                   <Divider orientation="left">Configuration Values</Divider>
                   <Text
                     type="secondary"
-                    style={{ display: "block", marginBottom: 12, fontSize: 12 }}
+                    style={{
+                      display: "block",
+                      marginBottom: 12,
+                      fontSize: 12,
+                    }}
                   >
                     These values will be saved to your secrets file
                     (~/.config/mcpd/secrets.dev.toml).
@@ -983,7 +1281,67 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
                 </>
               )}
           </Form>
-        </Card>
+
+          {configPreview && (
+            <Collapse
+              defaultActiveKey={["config-preview", "secrets-preview"]}
+              style={{ marginTop: 16 }}
+            >
+              <Collapse.Panel
+                key="config-preview"
+                header={
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    <FileOutlined style={{ marginRight: 6 }} />
+                    {configPath || ".mcpd.toml"}
+                  </Text>
+                }
+              >
+                <pre
+                  style={{
+                    background: "#1e1e1e",
+                    color: "#d4d4d4",
+                    fontFamily: "monospace",
+                    fontSize: 12,
+                    padding: 12,
+                    borderRadius: 4,
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-all",
+                  }}
+                >
+                  <HighlightedToml content={configPreview} />
+                </pre>
+              </Collapse.Panel>
+              {secretsPreview && (
+                <Collapse.Panel
+                  key="secrets-preview"
+                  header={
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      <FileOutlined style={{ marginRight: 6 }} />
+                      {secretsPath || "secrets.dev.toml"}
+                    </Text>
+                  }
+                >
+                  <pre
+                    style={{
+                      background: "#1e1e1e",
+                      color: "#d4d4d4",
+                      fontFamily: "monospace",
+                      fontSize: 12,
+                      padding: 12,
+                      borderRadius: 4,
+                      margin: 0,
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-all",
+                    }}
+                  >
+                    <HighlightedToml content={secretsPreview} />
+                  </pre>
+                </Collapse.Panel>
+              )}
+            </Collapse>
+          )}
+        </div>
       )}
     </div>
   );
@@ -1059,24 +1417,6 @@ const AddServerModal: React.FC<AddServerModalProps> = ({
           {renderCustomMode()}
         </TabPane>
       </Tabs>
-
-      {tomlPreview && (
-        <div style={{ marginTop: 16 }}>
-          <Divider>Configuration Preview</Divider>
-          <MonacoEditor
-            height="150px"
-            language="toml"
-            theme="vs-dark"
-            value={tomlPreview}
-            options={{
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              lineNumbers: "off",
-            }}
-          />
-        </div>
-      )}
     </Modal>
   );
 };

--- a/src/renderer/components/ConfigEditor.tsx
+++ b/src/renderer/components/ConfigEditor.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { Card, Button, Space, message, Alert } from "antd";
+import { Card, Button, Space, message, Alert, Typography } from "antd";
 import {
   SaveOutlined,
   DownloadOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
+
+const { Text } = Typography;
 
 const ConfigEditor: React.FC = () => {
   const monaco = useMonaco();
@@ -34,21 +36,34 @@ const ConfigEditor: React.FC = () => {
       },
     });
   }, [monaco]);
+
   const [configContent, setConfigContent] = useState<string>("");
   const [originalContent, setOriginalContent] = useState<string>("");
   const [loading, setLoading] = useState(false);
 
+  const [secretsContent, setSecretsContent] = useState<string>("");
+  const [originalSecretsContent, setOriginalSecretsContent] =
+    useState<string>("");
+  const [secretsLoading, setSecretsLoading] = useState(false);
+
+  const [configPath, setConfigPath] = useState<string>("");
+  const [secretsPath, setSecretsPath] = useState<string>("");
+
   useEffect(() => {
     loadConfig();
+    loadSecrets();
+    window.electronAPI.getConfigPath().then(setConfigPath).catch(console.error);
+    window.electronAPI
+      .getSecretsPath()
+      .then(setSecretsPath)
+      .catch(console.error);
   }, []);
 
   const loadConfig = async () => {
     setLoading(true);
     try {
       const config = await window.electronAPI.loadConfig();
-      console.log("Loaded config:", config);
       const content = config.content || "servers = []";
-      console.log("Config content:", content);
       setConfigContent(content);
       setOriginalContent(content);
     } catch (error) {
@@ -70,6 +85,31 @@ const ConfigEditor: React.FC = () => {
     }
   };
 
+  const loadSecrets = async () => {
+    setSecretsLoading(true);
+    try {
+      const result = await window.electronAPI.loadSecretsContent();
+      setSecretsContent(result.content);
+      setOriginalSecretsContent(result.content);
+    } catch (error) {
+      console.error("Failed to load secrets:", error);
+      message.error("Failed to load secrets file");
+    } finally {
+      setSecretsLoading(false);
+    }
+  };
+
+  const saveSecrets = async () => {
+    try {
+      await window.electronAPI.saveSecretsContent(secretsContent);
+      setOriginalSecretsContent(secretsContent);
+      message.success("Secrets saved successfully");
+    } catch (error) {
+      console.error("Failed to save secrets:", error);
+      message.error("Failed to save secrets file");
+    }
+  };
+
   const exportConfig = async () => {
     try {
       const exportedConfig = await window.electronAPI.exportConfig();
@@ -87,20 +127,34 @@ const ConfigEditor: React.FC = () => {
     }
   };
 
-  const hasChanges = configContent !== originalContent;
+  const hasConfigChanges = configContent !== originalContent;
+  const hasSecretsChanges = secretsContent !== originalSecretsContent;
+  const hasChanges = hasConfigChanges || hasSecretsChanges;
 
   return (
     <div>
       <Alert
-        message="Configuration File (.mcpd.toml)"
-        description="Edit your mcpd configuration directly. Changes will be applied after saving and restarting the daemon."
+        message="Configuration Files"
+        description="Edit your mcpd configuration and secrets directly. Changes will be applied after saving and restarting the daemon."
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
       />
 
       <Card
-        title="Configuration Editor"
+        title={
+          <Space>
+            <span>Config</span>
+            {configPath && (
+              <Text
+                type="secondary"
+                style={{ fontSize: 12, fontWeight: "normal" }}
+              >
+                {configPath}
+              </Text>
+            )}
+          </Space>
+        }
         extra={
           <Space>
             <Button
@@ -117,9 +171,9 @@ const ConfigEditor: React.FC = () => {
               type="primary"
               icon={<SaveOutlined />}
               onClick={saveConfig}
-              disabled={!hasChanges}
+              disabled={!hasConfigChanges}
             >
-              Save {hasChanges && "*"}
+              Save {hasConfigChanges && "*"}
             </Button>
           </Space>
         }
@@ -130,12 +184,76 @@ const ConfigEditor: React.FC = () => {
           </div>
         ) : (
           <MonacoEditor
-            height="calc(100vh - 370px)"
+            height="30vh"
             language="toml"
             theme="vs-dark"
             value={configContent}
             onChange={(value) => setConfigContent(value || "")}
             loading={loading}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 14,
+              lineNumbers: "on",
+              wordWrap: "on",
+              scrollBeyondLastLine: false,
+              scrollbar: {
+                vertical: "auto",
+                horizontal: "auto",
+              },
+              formatOnPaste: true,
+              formatOnType: true,
+            }}
+          />
+        )}
+      </Card>
+
+      <Card
+        title={
+          <Space>
+            <span>Secrets</span>
+            {secretsPath && (
+              <Text
+                type="secondary"
+                style={{ fontSize: 12, fontWeight: "normal" }}
+              >
+                {secretsPath}
+              </Text>
+            )}
+          </Space>
+        }
+        extra={
+          <Space>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={loadSecrets}
+              loading={secretsLoading}
+            >
+              Reload
+            </Button>
+            <Button
+              type="primary"
+              icon={<SaveOutlined />}
+              onClick={saveSecrets}
+              disabled={!hasSecretsChanges}
+            >
+              Save {hasSecretsChanges && "*"}
+            </Button>
+          </Space>
+        }
+        style={{ marginTop: 16 }}
+      >
+        {secretsLoading ? (
+          <div style={{ padding: 20, textAlign: "center" }}>
+            Loading secrets...
+          </div>
+        ) : (
+          <MonacoEditor
+            height="30vh"
+            language="toml"
+            theme="vs-dark"
+            value={secretsContent}
+            onChange={(value) => setSecretsContent(value || "")}
+            loading={secretsLoading}
             options={{
               minimap: { enabled: false },
               fontSize: 14,

--- a/src/renderer/components/ServerManager.tsx
+++ b/src/renderer/components/ServerManager.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   message,
   Popconfirm,
+  Tooltip,
 } from "antd";
 import {
   PlusOutlined,
@@ -27,9 +28,14 @@ const ServerManager: React.FC<ServerManagerProps> = ({ onViewTools }) => {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(false);
   const [addModalVisible, setAddModalVisible] = useState(false);
+  const [mcpdInstalled, setMcpdInstalled] = useState<boolean | null>(null);
 
   useEffect(() => {
     loadServers();
+    window.electronAPI
+      .isMcpdInstalled()
+      .then(setMcpdInstalled)
+      .catch(console.error);
   }, []);
 
   const loadServers = async () => {
@@ -202,13 +208,24 @@ const ServerManager: React.FC<ServerManagerProps> = ({ onViewTools }) => {
             <Button icon={<ReloadOutlined />} onClick={loadServers}>
               Refresh
             </Button>
-            <Button
-              type="primary"
-              icon={<PlusOutlined />}
-              onClick={() => setAddModalVisible(true)}
+            <Tooltip
+              title={
+                mcpdInstalled === false
+                  ? "Install mcpd to add servers"
+                  : undefined
+              }
             >
-              Add Server
-            </Button>
+              <span>
+                <Button
+                  type="primary"
+                  icon={<PlusOutlined />}
+                  onClick={() => setAddModalVisible(true)}
+                  disabled={mcpdInstalled === false}
+                >
+                  Add Server
+                </Button>
+              </span>
+            </Tooltip>
           </Space>
         }
       >

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -68,6 +68,29 @@ export interface IpcChannels {
     args: string[],
   ) => Promise<void>;
   "secrets:path": () => Promise<string>;
+  "secrets:set-env": (
+    name: string,
+    env: Record<string, string>,
+  ) => Promise<void>;
+  "secrets:set-args": (
+    name: string,
+    positionalArgs: string[],
+    cliArgs: string[],
+    boolArgs: string[],
+  ) => Promise<void>;
+  "secrets:load": () => Promise<{ content: string }>;
+  "secrets:save": (content: string) => Promise<void>;
+
+  // Config path
+  "config:path": () => Promise<string>;
+
+  // Registry-based server addition via mcpd CLI
+  "servers:add-registry": (
+    name: string,
+    runtime: string,
+    version: string,
+    tools: string[],
+  ) => Promise<void>;
 }
 
 export interface LogEntry {


### PR DESCRIPTION
## Summary

- Show all configured servers in the Servers tab regardless of daemon state — servers not reported by the daemon appear with "stopped" status and "unknown" health
- Add mcpd CLI integration for registry-based server addition (`mcpd add`), environment variable setting, and argument configuration
- Add secrets file editing alongside config in the Config Editor tab with file path display
- Refactor AddServerModal with TOML preview highlighting and streamlined flow
- Extract `restartDaemonIfRunning` and `runMcpdCommand` helpers in McpdManager

## Test plan

- [ ] Stop daemon → Servers tab shows configured servers with STOPPED status
- [ ] Start daemon → Servers tab shows servers with RUNNING/HEALTHY status
- [ ] Remove a stopped server → it disappears from the list and from `.mcpd.toml`
- [ ] Add a server from the registry via the new modal flow
- [ ] Edit secrets in Config Editor and verify changes are saved